### PR TITLE
タイマーの回数制限を超えたときに終了するようにした

### DIFF
--- a/lib/rclex/timer.ex
+++ b/lib/rclex/timer.ex
@@ -10,13 +10,13 @@ defmodule Rclex.Timer do
     count = count + 1
 
     if(count > limit) do
-      raise "input times repeated"
+      IO.puts "input times repeated"
+    else
+      callback.(publisher_list)
+      # timeはミリ秒
+      :timer.sleep(time)
+      timer_loop(publisher_list, time, callback, count, limit)
     end
-
-    callback.(publisher_list)
-    # timeはミリ秒
-    :timer.sleep(time)
-    timer_loop(publisher_list, time, callback, count, limit)
   end
 
   def timer_loop(publisher_list, time, callback) do

--- a/lib/rclex/timer.ex
+++ b/lib/rclex/timer.ex
@@ -10,7 +10,8 @@ defmodule Rclex.Timer do
     count = count + 1
 
     if(count > limit) do
-      IO.puts "input times repeated"
+      IO.puts "info: the number of count reaches limit"
+      :ok
     else
       callback.(publisher_list)
       # timeはミリ秒
@@ -52,7 +53,7 @@ defmodule Rclex.Timer do
 
     {:ok, child} =
       Task.Supervisor.start_child(sv, Rclex.Timer, :timer_loop, [pub_list, time, callback],
-        restart: :transient
+        restart: :temporary
       )
 
     {sv, child}


### PR DESCRIPTION
既存の実装だと回数制限を超えた際にエラーを出した後再びループに入っていたところを修正し、回数制限を超えた後はそのまま終了するようにしました。
エラーではなくIO.putsにしたのはエラーの場合うまく終了しない場合があったためです。