### PR TITLE
ROS2 Foxyに対応した。

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dockertags: [latest, dashing-ex1.12.0-otp24.0.1, dashing-ex1.11.2-otp23.3.1, dashing-ex1.10.4-otp22.3.4, dashing-ex1.9.4-otp22.3.4, dashing-ex1.9.1-otp22.0.7]
+        dockertags: [latest, dashing-ex1.12.0-otp24.0.1, dashing-ex1.11.2-otp23.3.1, dashing-ex1.10.4-otp22.3.4, dashing-ex1.9.4-otp22.3.4, dashing-ex1.9.1-otp22.0.7, foxy-ex1.12.0-otp24.0.1, foxy-ex1.11.2-otp23.3.1]
     container: rclex/rclex_docker:${{ matrix.dockertags }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
         - name: mix compile
           run: |
-            source /opt/ros/dashing/setup.bash
+            source /opt/ros/${ROS_DISTRO}/setup.bash
             cd rclex
             mix local.hex --force
             mix deps.get
@@ -37,13 +37,13 @@ jobs:
 
         - name: mix test
           run: |
-            source /opt/ros/dashing/setup.bash
+            source /opt/ros/${ROS_DISTRO}/setup.bash
             cd rclex
             mix test
 
         - name: connection tests
           run: | 
-            source /opt/ros/dashing/setup.bash
+            source /opt/ros/${ROS_DISTRO}/setup.bash
             cd rclex_connection_tests
             ./run-all.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
 # set directory for ROSDISTRO
-ROSDIR = /opt/ros/dashing
+ROS_DIR = /opt/ros/foxy
+
+ifeq ($(ROS_DIR), /opt/ros/dashing)
+	ROS_VERSION = DASHING
+	TYPE_STRUCTURE_DIR = rosidl_generator_c
+else ifeq ($(ROS_DIR), /opt/ros/foxy)
+	ROS_VERSION = FOXY
+	TYPE_STRUCTURE_DIR = rosidl_runtime_c
+else
+# どうする？
+endif
 
 CC = gcc
 LD = ld
@@ -18,10 +28,10 @@ ERL_CFLAGS  ?= -I$(ERL_EI_INCLUDE_DIR)
 ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR)
 
 # for ROS libs
-ROS_CFLAGS  ?= -I$(ROSDIR)/include
-ROS_LDFLAGS ?= -L$(ROSDIR)/lib
+ROS_CFLAGS  ?= -I$(ROS_DIR)/include
+ROS_LDFLAGS ?= -L$(ROS_DIR)/lib
 ROS_LDFLAGS += -lrcl -lrmw -lrcutils \
-	-lrosidl_generator_c -lrosidl_typesupport_c \
+	-l$(TYPE_STRUCTURE_DIR) -lrosidl_typesupport_c \
 	-lrosidl_typesupport_introspection_c \
 	-lstd_msgs__rosidl_generator_c -lstd_msgs__rosidl_typesupport_c \
 	-lfastcdr -lfastrtps -lrmw_fastrtps_cpp
@@ -40,7 +50,7 @@ install: $(PREFIX) $(BUILD) $(NIF)
 $(OBJ): $(HEADERS) Makefile
 
 $(BUILD)/%.o: src/%.c
-	$(CC) -c $(ERL_CFLAGS) $(ROS_CFLAGS) $(CFLAGS) -o $@ $<
+	$(CC) -c $(ERL_CFLAGS) $(ROS_CFLAGS) $(CFLAGS) -D$(ROS_VERSION) -o $@ $<
 
 $(NIF): $(OBJ)
 	$(CC) -o $@ $(ERL_LDFLAGS) $(LDFLAGS) $^ $(ROS_LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # set directory for ROSDISTRO
-ROS_DIR = /opt/ros/foxy
+ROS_DIR = /opt/ros/dashing
 
 ifeq ($(ROS_DIR), /opt/ros/dashing)
 	ROS_VERSION = DASHING
@@ -7,8 +7,6 @@ ifeq ($(ROS_DIR), /opt/ros/dashing)
 else ifeq ($(ROS_DIR), /opt/ros/foxy)
 	ROS_VERSION = FOXY
 	TYPE_STRUCTURE_DIR = rosidl_runtime_c
-else
-# どうする？
 endif
 
 CC = gcc

--- a/README.md
+++ b/README.md
@@ -39,21 +39,22 @@ Currently, the Rclex API allows for the following:
 Please reference examples [here](https://github.com/rclex/rclex_samples). Also note the usage alongside the sample code.
 
 
-## Supported Environment (for the development)
+## Recommended Environment
 
 Currently, we use the following environment as the development target:
 
-- Ubuntu 18.04.5 LTS
-- ROS 2 [Dashing Diademata](https://index.ros.org/doc/ros2/Releases/Release-Dashing-Diademata/)
+- Ubuntu 20.04.2 LTS (Focal Fossa)
+- ROS 2 [Foxy Fitzroy](https://docs.ros.org/en/foxy/Releases/Release-Foxy-Fitzroy.html)
+  - also work well on Ubuntu 18.04.5 LTS and [Dashing Diademata](https://index.ros.org/doc/ros2/Releases/Release-Dashing-Diademata/)
 - Elixir 1.11.2-otp-23
 - Erlang/OTP 23.3.1
 
-As an operation check, we are testing the communication with the node implemented by Rclcpp using [rclex/rclex_connection_tests](https://github.com/rclex/rclex_connection_tests).
+As an operation test, we check the communication with nodes implemented by [rclcpp](https://github.com/ros2/rclcpp) using [rclex/rclex_connection_tests](https://github.com/rclex/rclex_connection_tests).
 
-We run CI in multiple different environments on [GitHub Actions](https://github.com/rclex/rclex/actions). 
+We also run CI in multiple different environments on [GitHub Actions](https://github.com/rclex/rclex/actions). 
 However, please note that we cannot guarantee the operation of all of these versions due to our limited development resources.
 
-We also publish [the pre-built Docker image on Docker Hub](https://hub.docker.com/r/rclex/rclex_docker) used in CI.
+The pre-built Docker images used in CI have published on [Docker Hub](https://hub.docker.com/r/rclex/rclex_docker).
 You can also try the power of Rclex with it easily.
 
 ## Installation

--- a/src/msg_int16_nif.c
+++ b/src/msg_int16_nif.c
@@ -5,7 +5,13 @@ extern "C"
 
 #include <erl_nif.h>
 #include <rcl/rcl.h>
+
+#ifdef DASHING
 #include <rosidl_generator_c/message_type_support_struct.h>
+#elseif FOXY
+#include <rosidl_runtime_c/message_type_support_struct.h>
+#endif
+
 
 #include <std_msgs/msg/int16.h>
 #include "total_nif.h"

--- a/src/msg_int16_nif.c
+++ b/src/msg_int16_nif.c
@@ -8,7 +8,7 @@ extern "C"
 
 #ifdef DASHING
 #include <rosidl_generator_c/message_type_support_struct.h>
-#elseif FOXY
+#elif FOXY
 #include <rosidl_runtime_c/message_type_support_struct.h>
 #endif
 

--- a/src/msg_string_nif.c
+++ b/src/msg_string_nif.c
@@ -7,7 +7,7 @@ extern "C"
 #include <rcl/rcl.h>
 #ifdef DASHING
 #include <rosidl_generator_c/message_type_support_struct.h>
-#elseif FOXY
+#elif FOXY
 #include <rosidl_runtime_c/message_type_support_struct.h>
 #endif
 

--- a/src/msg_string_nif.c
+++ b/src/msg_string_nif.c
@@ -7,8 +7,10 @@ extern "C"
 #include <rcl/rcl.h>
 #ifdef DASHING
 #include <rosidl_generator_c/message_type_support_struct.h>
+#define __STRING__ASSIGN rosidl_generator_c__String__assign
 #elif FOXY
 #include <rosidl_runtime_c/message_type_support_struct.h>
+#define __STRING__ASSIGN rosidl_runtime_c__String__assign
 #endif
 
 #include <std_msgs/msg/string.h>
@@ -68,7 +70,7 @@ ERL_NIF_TERM nif_setdata_string(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
         return enif_make_badarg(env);
     }
     //String型の構造体に引数の文字列とサイズを入れる．
-    rosidl_runtime_c__String__assign(res_msg,data_buf);
+    __STRING__ASSIGN(res_msg,data_buf);
     free(data_buf);
     return enif_make_atom(env,"ok");
 }

--- a/src/msg_string_nif.c
+++ b/src/msg_string_nif.c
@@ -5,7 +5,11 @@ extern "C"
 
 #include <erl_nif.h>
 #include <rcl/rcl.h>
+#ifdef DASHING
 #include <rosidl_generator_c/message_type_support_struct.h>
+#elseif FOXY
+#include <rosidl_runtime_c/message_type_support_struct.h>
+#endif
 
 #include <std_msgs/msg/string.h>
 
@@ -64,7 +68,7 @@ ERL_NIF_TERM nif_setdata_string(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
         return enif_make_badarg(env);
     }
     //String型の構造体に引数の文字列とサイズを入れる．
-    rosidl_generator_c__String__assign(res_msg,data_buf);
+    rosidl_runtime_c__String__assign(res_msg,data_buf);
     free(data_buf);
     return enif_make_atom(env,"ok");
 }

--- a/src/publisher_nif.c
+++ b/src/publisher_nif.c
@@ -11,7 +11,7 @@ extern "C"
 #include "rcl/publisher.h"
 #ifdef DASHING
 #include <rosidl_generator_c/message_type_support_struct.h>
-#elseif FOXY
+#elif FOXY
 #include <rosidl_runtime_c/message_type_support_struct.h>
 #endif
 

--- a/src/publisher_nif.c
+++ b/src/publisher_nif.c
@@ -9,7 +9,11 @@ extern "C"
 #include <string.h>
 
 #include "rcl/publisher.h"
+#ifdef DASHING
 #include <rosidl_generator_c/message_type_support_struct.h>
+#elseif FOXY
+#include <rosidl_runtime_c/message_type_support_struct.h>
+#endif
 
 #include <std_msgs/msg/int16.h>
 #include <std_msgs/msg/string.h>

--- a/src/subscription_nif.c
+++ b/src/subscription_nif.c
@@ -13,7 +13,7 @@ extern "C"
 
 #ifdef DASHING
 #include <rosidl_generator_c/message_type_support_struct.h>
-#elseif FOXY
+#elif FOXY
 #include <rosidl_runtime_c/message_type_support_struct.h>
 #endif
 

--- a/src/subscription_nif.c
+++ b/src/subscription_nif.c
@@ -11,7 +11,11 @@ extern "C"
 #include "rcl/subscription.h"
 #include "rmw/types.h"
 
+#ifdef DASHING
 #include <rosidl_generator_c/message_type_support_struct.h>
+#elseif FOXY
+#include <rosidl_runtime_c/message_type_support_struct.h>
+#endif
 
 #include <std_msgs/msg/int16.h>
 #include <std_msgs/msg/string.h>


### PR DESCRIPTION
Foxyに対応しました。また、それに伴ってMakefileのROS2バージョンの指定をDashingで固定していたのを環境変数を読み込んで自動で判別するようにしました。
DashingとFoxyで一部ディレクトリが変更されており、それをバージョンによって読み分けるようにしています。また関数名も一部異なっているのでマクロに置き換えています。