### PR TITLE
release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## v0.4.0 on 8 Jun 2021
+
+- Support for [ROS 2 Foxy Fitzroy](https://index.ros.org/doc/ros2/Releases/Release-Foxy-Fitzroy/)!! #32 :tada:
+- Recommended environment is now Ubuntu 20.04.2 LTS / ROS 2 Foxy / Elixir 1.11.2-otp-23 / Erlang/OTP 23.3.1
+  - also work well on Ubuntu 18.04.5 LTS and Dashing Diademata
+- Introduce automatic test a.k.a CI works on [GitHub Actions](https://github.com/rclex/rclex/actions) #13 #25 #31 
+  - Please also check [rclex_connection_tests](https://github.com/rclex/rclex_connection_tests) and [rclex_docker on Docker Hub](https://hub.docker.com/r/rclex/rclex_docker) for more details
+  - Note that CI sometimes fails due to the performance of GHA runner #28 
+- Implement subsucribe_stop/2 #30
+- Fix bug on timer_loop/4 #29 #21 
+- Create [rclex Organization](https://github.com/rclex) and change source URL #18
+- Please welcome @kebus426 as a new maintainer! 
+
 ## v0.3.1 on 4 Jul 2020
 
 - Translate README from Japanese to English #11

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:rclex, "~> 0.3.1"}
+    {:rclex, "~> 0.4.0"}
   ]
 end
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -56,7 +56,7 @@ ROSからの大きな違いとして，通信にDDS（Data Distribution Service�
 ```elixir
 def deps do
   [
-    {:rclex, "~> 0.3.1"}
+    {:rclex, "~> 0.4.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Rclex.MixProject do
   ROS 2 Client Library for Elixir.
   """
 
-  @version "0.3.1"
+  @version "0.4.0"
   @source_url "https://github.com/rclex/rclex"
 
   def project do


### PR DESCRIPTION
- Support for [ROS 2 Foxy Fitzroy](https://index.ros.org/doc/ros2/Releases/Release-Foxy-Fitzroy/)!! #32 :tada:
- Recommended environment is now Ubuntu 20.04.2 LTS / ROS 2 Foxy / Elixir 1.11.2-otp-23 / Erlang/OTP 23.3.1
  - also work well on Ubuntu 18.04.5 LTS and Dashing Diademata
- Introduce automatic test a.k.a CI works on [GitHub Actions](https://github.com/rclex/rclex/actions) #13 #25 #31 
  - Please also check [rclex_connection_tests](https://github.com/rclex/rclex_connection_tests) and [rclex_docker on Docker Hub](https://hub.docker.com/r/rclex/rclex_docker) for more details
  - Note that CI sometimes fails due to the performance of GHA runner #28 
- Implement subsucribe_stop/2 #30 
- Fix bug on timer_loop/4 #29 #21 
- Create [rclex Organization](https://github.com/rclex) and change source URL #18
- Please welcome @kebus426 as a new maintainer! 