### PR TITLE
Separate ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,46 +16,45 @@ jobs:
     container: rclex/rclex_docker:${{ matrix.dockertags }}
 
     steps:
-        - name: clone rclex
-          uses: actions/checkout@v2
-          with: 
-            repository: rclex/rclex
-            path: rclex
-        - name: clone rclex_connection_tests
-          uses: actions/checkout@v2
-          with:
-            repository: rclex/rclex_connection_tests
-            path: rclex_connection_tests
+      - name: clone rclex
+        uses: actions/checkout@v2
+        with: 
+          repository: rclex/rclex
+          path: rclex
+      - name: clone rclex_connection_tests
+        uses: actions/checkout@v2
+        with:
+          repository: rclex/rclex_connection_tests
+          path: rclex_connection_tests
 
-        - name: mix compile
-          run: |
-            source /opt/ros/${ROS_DISTRO}/setup.bash
-            cd rclex
-            mix local.hex --force
-            mix deps.get
-            mix compile
+      - name: mix compile
+        run: |
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          cd rclex
+          mix local.hex --force
+          mix deps.get
+          mix compile
 
-        - name: mix format
-          run: |
-            source /opt/ros/${ROS_DISTRO}/setup.bash
-            cd rclex
-            mix format --check-formatted
+      - name: mix format
+        run: |
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          cd rclex
+          mix format --check-formatted
 
-        - name: mix credo
-          run: |
-            source /opt/ros/${ROS_DISTRO}/setup.bash
-            cd rclex
-            mix credo --all
+      - name: mix credo
+        run: |
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          cd rclex
+          mix credo --all
 
-        - name: mix test
-          run: |
-            source /opt/ros/${ROS_DISTRO}/setup.bash
-            cd rclex
-            mix test
+      - name: mix test
+        run: |
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          cd rclex
+          mix test
 
-        - name: connection tests
-          run: | 
-            source /opt/ros/${ROS_DISTRO}/setup.bash
-            cd rclex_connection_tests
-            ./run-all.sh
-
+      - name: connection tests
+        run: | 
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          cd rclex_connection_tests
+          ./run-all.sh

--- a/.github/workflows/ci_allver.yml
+++ b/.github/workflows/ci_allver.yml
@@ -1,0 +1,60 @@
+name: ci-all_version
+
+on: [pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  CI_on_PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dockertags: [latest, dashing-ex1.12.0-otp24.0.1, dashing-ex1.11.2-otp23.3.1, dashing-ex1.10.4-otp22.3.4, dashing-ex1.9.4-otp22.3.4, dashing-ex1.9.1-otp22.0.7, foxy-ex1.12.0-otp24.0.1, foxy-ex1.11.2-otp23.3.1]
+    container: rclex/rclex_docker:${{ matrix.dockertags }}
+
+    steps:
+      - name: clone rclex
+        uses: actions/checkout@v2
+        with: 
+          repository: rclex/rclex
+          path: rclex
+      - name: clone rclex_connection_tests
+        uses: actions/checkout@v2
+        with:
+          repository: rclex/rclex_connection_tests
+          path: rclex_connection_tests
+
+      - name: mix compile
+        run: |
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          cd rclex
+          mix local.hex --force
+          mix deps.get
+          mix compile
+
+      - name: mix format
+        run: |
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          cd rclex
+          mix format --check-formatted
+
+      - name: mix credo
+        run: |
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          cd rclex
+          mix credo --all
+
+      - name: mix test
+        run: |
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          cd rclex
+          mix test
+
+      - name: connection tests
+        run: | 
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          cd rclex_connection_tests
+          ./run-all.sh

--- a/.github/workflows/ci_latest.yml
+++ b/.github/workflows/ci_latest.yml
@@ -1,4 +1,4 @@
-name: ci-all_version
+name: ci-latest
 
 on: [push]
 
@@ -7,12 +7,12 @@ defaults:
     shell: bash
 
 jobs:
-  rclex_test:
+  CI_on_push:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        dockertags: [latest, dashing-ex1.12.0-otp24.0.1, dashing-ex1.11.2-otp23.3.1, dashing-ex1.10.4-otp22.3.4, dashing-ex1.9.4-otp22.3.4, dashing-ex1.9.1-otp22.0.7, foxy-ex1.12.0-otp24.0.1, foxy-ex1.11.2-otp23.3.1]
+        dockertags: [latest]
     container: rclex/rclex_docker:${{ matrix.dockertags }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![Hex version](https://img.shields.io/hexpm/v/rclex.svg "Hex version")](https://hex.pm/packages/rclex)
 [![API docs](https://img.shields.io/hexpm/v/rclex.svg?label=hexdocs "API docs")](https://hexdocs.pm/rclex/readme.html)
 [![License](https://img.shields.io/hexpm/l/rclex.svg)](https://github.com/rclex/rclex/blob/main/LICENSE)
-[![ci-all_version](https://github.com/rclex/rclex/actions/workflows/ci.yml/badge.svg)](https://github.com/rclex/rclex/actions/workflows/ci.yml)
+[![ci-latest_push](https://github.com/rclex/rclex/actions/workflows/ci_latest.yml/badge.svg)](https://github.com/rclex/rclex/actions/workflows/ci_latest.yml)
+[![ci-allver_PR](https://github.com/rclex/rclex/actions/workflows/ci_allver.yml/badge.svg)](https://github.com/rclex/rclex/actions/workflows/ci_allver.yml)
 
 [日本語のREADME](README_ja.md)
 


### PR DESCRIPTION
This PR separate `ci.yml` into `ci_latest.yml` and `ci_allver.yml`.

- `ci_latest.yml`: do CI only on rclex/rclex_docker:latest and push.
- `ci_allver.yml`: do CI on all tags of container and pull request.