### PR TITLE
release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # CHANGELOG
 
-## v0.5.0 on 21 Oct 2021
+## v0.5.0 on 01 Nov 2021
 
 - New features:
-  - Implement `Executor` module by using GenServer #61
+  - Implement `Executor` module by using GenServer #61 #67
 - Code Improvements/Fixes:
   - Hide NIF functions from users #54 #55
 - Bumps:
   - `ex_doc` to 0.25.5 #63
   - `elixir_make` to 0.6.3 #62
+- Known issues:
+  - `mix test` sometimes fails, but we don't think it will affect the behavior #68
 
 ## v0.4.1 on 24 Jul 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v0.5.0 on 21 Oct 2021
+
+- New features:
+  - Implement `Executor` module by using GenServer #61
+- Code Improvements/Fixes:
+  - Hide NIF functions from users #54 #55
+- Bumps:
+  - `ex_doc` to 0.25.5 #63
+  - `elixir_make` to 0.6.3 #62
+
 ## v0.4.1 on 24 Jul 2021
 
 - New features:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:rclex, "~> 0.4.1"}
+    {:rclex, "~> 0.5.0"}
   ]
 end
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -56,7 +56,7 @@ ROSからの大きな違いとして，通信にDDS（Data Distribution Service�
 ```elixir
 def deps do
   [
-    {:rclex, "~> 0.4.1"}
+    {:rclex, "~> 0.5.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Rclex.MixProject do
   ROS 2 Client Library for Elixir.
   """
 
-  @version "0.4.1"
+  @version "0.5.0"
   @source_url "https://github.com/rclex/rclex"
 
   def project do


### PR DESCRIPTION
## v0.5.0 on 21 Oct 2021

- New features:
  - Implement `Executor` module by using GenServer #61
- Code Improvements/Fixes:
  - Hide NIF functions from users #54 #55
- Bumps:
  - `ex_doc` to 0.25.5 #63
  - `elixir_make` to 0.6.3 #62