### PR TITLE
Some minor refactoring to remove boring warning in `mix compile`

### DIFF
--- a/lib/rclex.ex
+++ b/lib/rclex.ex
@@ -80,7 +80,7 @@ defmodule Rclex do
       |> String.to_integer()
 
     case num do
-      0 -> Rclex.Timer.terminate_timer(sv, child)
+      0 -> Rclex.Timer.terminate(sv, child)
       _ -> waiting_input(sv, child)
     end
   end

--- a/lib/rclex/executor.ex
+++ b/lib/rclex/executor.ex
@@ -15,7 +15,7 @@ defmodule Rclex.Executor do
   @doc """
       Executorプロセスの初期化
       下位プロセスとしてJobQueue, JobExecutorプロセスを生成する
-      状態: 
+      状態:
           supervisor_ids :: map()
           keyがnode_identifer、valueがnode情報。現在はnodeプロセスのsupervisorのidを格納している
   """
@@ -26,14 +26,15 @@ defmodule Rclex.Executor do
     ]
 
     opts = [strategy: :one_for_one]
-    {:ok, id} = Supervisor.start_link(children, opts)
+    # {:ok, id} = Supervisor.start_link(children, opts)
+    {:ok, _} = Supervisor.start_link(children, opts)
     {:ok, {%{}}}
   end
 
   @doc """
       ノードをひとつだけ作成
       名前空間の有無を設定可能
-      返り値: 
+      返り値:
           node_identifier :: string()
           作成したノードプロセスのnameを返す
   """
@@ -48,7 +49,7 @@ defmodule Rclex.Executor do
   @doc """
       複数ノード生成
       create_nodes/4ではcreate_nodes/3に加えて名前空間の指定が可能
-      り値: 
+      返り値:
           node_identifier_list :: Enumerable.t()
           作成したノードプロセスのnameのリストを返す
   """

--- a/lib/rclex/job_executor.ex
+++ b/lib/rclex/job_executor.ex
@@ -1,5 +1,4 @@
 defmodule Rclex.JobExecutor do
-  alias Rclex.Nifs
   require Rclex.Macros
   require Logger
   use GenServer, restart: :transient

--- a/lib/rclex/job_queue.ex
+++ b/lib/rclex/job_queue.ex
@@ -1,5 +1,4 @@
 defmodule Rclex.JobQueue do
-  alias Rclex.Nifs
   require Rclex.Macros
   require Logger
   use GenServer, restart: :transient

--- a/lib/rclex/keep_sub.ex
+++ b/lib/rclex/keep_sub.ex
@@ -8,10 +8,6 @@ defmodule Rclex.KeepSub do
     subscribe_loopの中に適宜スリープを挟むことでCPU使用率は下げられる
   """
 
-  defp do_nothing do
-    # noop
-  end
-
   def take_once(takemsg, sub, msginfo, sub_alloc, callback) do
     case Nifs.rcl_take(sub, takemsg, msginfo, sub_alloc) do
       {Rclex.Macros.rcl_ret_ok(), _, _, _} ->
@@ -50,5 +46,9 @@ defmodule Rclex.KeepSub do
         restart: :transient
       )
     end)
+  end
+
+  defp do_nothing do
+    # noop
   end
 end

--- a/lib/rclex/publisher.ex
+++ b/lib/rclex/publisher.ex
@@ -63,7 +63,7 @@ defmodule Rclex.Publisher do
     {:reply, {:ok, 'publisher finished: '}, pub}
   end
 
-  def terminate(:normal, pub) do
+  def terminate(:normal, _) do
     Logger.debug("terminate publisher")
   end
 

--- a/lib/rclex/sub_loop.ex
+++ b/lib/rclex/sub_loop.ex
@@ -91,12 +91,12 @@ defmodule Rclex.SubLoop do
 
   # def terminate(:normal, state) do
   def terminate(:normal, _) do
-    Logger.debug("loop process killed : normal")
+    Logger.debug("sub_loop process killed : normal")
   end
 
   # def terminate(:shutdown, state) do
   def terminate(:shutdown, _) do
-    Logger.debug("loop process killed : shutdown")
+    Logger.debug("sub_loop process killed : shutdown")
   end
 
   def do_nothing() do

--- a/lib/rclex/sub_loop.ex
+++ b/lib/rclex/sub_loop.ex
@@ -55,7 +55,7 @@ defmodule Rclex.SubLoop do
           Logger.error("subscription invalid")
 
         {Rclex.Macros.rcl_ret_subscription_take_failed(), _, _, _} ->
-          do_nothing
+          do_nothing()
       end
     end
   end

--- a/lib/rclex/sub_loop.ex
+++ b/lib/rclex/sub_loop.ex
@@ -39,7 +39,8 @@ defmodule Rclex.SubLoop do
       購読処理関数
       購読が正常に行われれば，引数に受け取っていたコールバック関数を実行
   """
-  def each_subscribe(sub, call_back, sub_id) do
+  # def each_subscribe(sub, call_back, sub_id) do
+  def each_subscribe(sub, sub_id) do
     # Logger.debug("each subscribe")
     if Nifs.check_subscription(sub) do
       msg = Rclex.initialize_msg()
@@ -74,9 +75,9 @@ defmodule Rclex.SubLoop do
     # 待機時間によってCPU使用率，購読までの時間は変わる
     Nifs.rcl_wait(wait_set, 50)
 
-    each_subscribe(waitset_sub, call_back, sub_id)
+    # each_subscribe(waitset_sub, call_back, sub_id)
+    each_subscribe(waitset_sub, sub_id)
 
-    # 
     receive do
       :stop ->
         Process.send(sub_id, :terminate, [:noconnect])
@@ -88,11 +89,13 @@ defmodule Rclex.SubLoop do
     end
   end
 
-  def terminate(:normal, state) do
+  # def terminate(:normal, state) do
+  def terminate(:normal, _) do
     Logger.debug("loop process killed : normal")
   end
 
-  def terminate(:shutdown, state) do
+  # def terminate(:shutdown, state) do
+  def terminate(:shutdown, _) do
     Logger.debug("loop process killed : shutdown")
   end
 

--- a/lib/rclex/subscriber.ex
+++ b/lib/rclex/subscriber.ex
@@ -97,7 +97,4 @@ defmodule Rclex.Subscriber do
   def terminate(:normal, _) do
     Logger.debug("terminate subscriber")
   end
-
-  # defp do_nothing do
-  # end
 end

--- a/lib/rclex/subscriber.ex
+++ b/lib/rclex/subscriber.ex
@@ -95,7 +95,7 @@ defmodule Rclex.Subscriber do
   end
 
   def terminate(:normal, _) do
-    Logger.debug("sub terminate")
+    Logger.debug("terminate subscriber")
   end
 
   # defp do_nothing do

--- a/lib/rclex/timer.ex
+++ b/lib/rclex/timer.ex
@@ -50,4 +50,8 @@ defmodule Rclex.Timer do
     Supervisor.stop(loop_supervisor_id)
     {:stop, :normal, {callback, args, time, loop_supervisor_id}}
   end
+
+  def terminate(:normal, _) do
+    Logger.debug("terminate timer")
+  end
 end

--- a/lib/rclex/timer_loop.ex
+++ b/lib/rclex/timer_loop.ex
@@ -69,7 +69,4 @@ defmodule Rclex.TimerLoop do
   def terminate(:shutdown, _) do
     Logger.debug("timer_loop process killed : shutdown")
   end
-
-  def do_nothing() do
-  end
 end

--- a/lib/rclex/timer_loop.ex
+++ b/lib/rclex/timer_loop.ex
@@ -62,6 +62,14 @@ defmodule Rclex.TimerLoop do
     end
   end
 
+  def terminate(:normal, _) do
+    Logger.debug("timer_loop process killed : normal")
+  end
+
+  def terminate(:shutdown, _) do
+    Logger.debug("timer_loop process killed : shutdown")
+  end
+
   def do_nothing() do
   end
 end


### PR DESCRIPTION
also, implement Timer.terminate/2 and fix related message https://github.com/rclex/rclex/pull/73/commits/2915de5a7bdaa3ca22b56c7900d03a9931e057f9

This will fix #65 