### PR TITLE
publish without executor

### DIFF
--- a/lib/rclex/publisher.ex
+++ b/lib/rclex/publisher.ex
@@ -46,7 +46,11 @@ defmodule Rclex.Publisher do
 
     Enum.map(0..(n - 1), fn index ->
       {node_identifier, topic_name, :pub} = Enum.at(publisher_list, index)
-      GenServer.cast({:global, node_identifier ++ '/' ++ topic_name}, {:publish, Enum.at(data, index)})
+
+      GenServer.cast(
+        {:global, node_identifier ++ '/' ++ topic_name},
+        {:publish, Enum.at(data, index)}
+      )
     end)
 
     :ok

--- a/lib/rclex/publisher.ex
+++ b/lib/rclex/publisher.ex
@@ -46,8 +46,7 @@ defmodule Rclex.Publisher do
 
     Enum.map(0..(n - 1), fn index ->
       {node_identifier, topic_name, :pub} = Enum.at(publisher_list, index)
-      key = {:global, node_identifier ++ '/' ++ topic_name}
-      GenServer.cast(JobQueue, {:push, {key, :publish, Enum.at(data, index)}})
+      GenServer.cast({:global, node_identifier ++ '/' ++ topic_name}, {:publish, Enum.at(data, index)})
     end)
 
     :ok


### PR DESCRIPTION
publishする際にもExecutor通していたので取り除きました。
timer使ってpublishすると2度executor通ってたことになるのでちょっと早くなるかもしれないです。