### PR TITLE
Release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## v0.5.2 on 30 Nov 2022
+
+- New features:
+  - Add timer name in args of `create_timer/4` and `create_timer/5` to treat timer ID ddf99cf
+  - Implement `ResourceServer` module #83
+    - `JobExecutor` and `JobQueue` will be created for each node and timer
+    - `Executor` has been obsoleted and changed to the above feature
+- Code Improvements/Fixes:
+  - change wait time 50 to 5 milliseconds #76
+  - change docker tags for CI test #78
+- Bumps:
+  - `ex_doc` to 0.27.3 #80
+  - `credo` to 1.6.2 #82
+- Known issues:
+  - `mix test` sometimes fails, but we don't think it will affect the behavior #68
+
 ## v0.5.1 on 30 Nov 2021
 
 - New features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v0.5.2 on 30 Nov 2022
+## v0.5.2 on 21 Jan 2022
 
 - New features:
   - Add timer name in args of `create_timer/4` and `create_timer/5` to treat timer ID ddf99cf

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:rclex, "~> 0.5.1"}
+    {:rclex, "~> 0.5.2"}
   ]
 end
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -56,7 +56,7 @@ ROSからの大きな違いとして，通信にDDS（Data Distribution Service�
 ```elixir
 def deps do
   [
-    {:rclex, "~> 0.5.1"}
+    {:rclex, "~> 0.5.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Rclex.MixProject do
   ROS 2 Client Library for Elixir.
   """
 
-  @version "0.5.1"
+  @version "0.5.2"
   @source_url "https://github.com/rclex/rclex"
 
   def project do


### PR DESCRIPTION
## v0.5.2 on 21 Jan 2022

- New features:
  - Add timer name in args of `create_timer/4` and `create_timer/5` to treat timer ID ddf99cf
  - Implement `ResourceServer` module #83
    - `JobExecutor` and `JobQueue` will be created for each node and timer
    - `Executor` has been obsoleted and changed to the above feature
- Code Improvements/Fixes:
  - change wait time 50 to 5 milliseconds #76
  - change docker tags for CI test #78
- Bumps:
  - `ex_doc` to 0.27.3 #80
  - `credo` to 1.6.2 #82
- Known issues:
  - `mix test` sometimes fails, but we don't think it will affect the behavior #68
