### PR TITLE
add executor settings api

### DIFF
--- a/lib/rclex/job_executor.ex
+++ b/lib/rclex/job_executor.ex
@@ -24,7 +24,7 @@ defmodule Rclex.JobExecutor do
     {:ok, {}}
   end
 
-  def init(change_order) do
+  def init({change_order}) do
     Logger.debug("JobExecutor start")
     {:ok, {change_order}}
   end
@@ -37,8 +37,8 @@ defmodule Rclex.JobExecutor do
   end
 
   def handle_cast({:execute, job_queue}, {change_order}) do
-    :queue.to_list(job_queue)
-    |> change_order.()
+    job_list = :queue.to_list(job_queue)
+    change_order.(job_list)
     |> Enum.map(fn {key, action, args} -> GenServer.cast(key, {action, args}) end)
 
     {:noreply, {change_order}}

--- a/lib/rclex/job_executor.ex
+++ b/lib/rclex/job_executor.ex
@@ -38,6 +38,7 @@ defmodule Rclex.JobExecutor do
 
   def handle_cast({:execute, job_queue}, {change_order}) do
     job_list = :queue.to_list(job_queue)
+
     change_order.(job_list)
     |> Enum.map(fn {key, action, args} -> GenServer.cast(key, {action, args}) end)
 

--- a/lib/rclex/node.ex
+++ b/lib/rclex/node.ex
@@ -17,15 +17,15 @@ defmodule Rclex.Node do
   end
 
   def start_link({node, node_name, :executor_setting, {queue_length, change_order}}) do
-    GenServer.start_link(__MODULE__, {node, node_name, queue_length, change_order}, name: {:global, node_name})
+    GenServer.start_link(__MODULE__, {node, node_name, queue_length, change_order},
+      name: {:global, node_name}
+    )
   end
 
   def start_link({node, node_name, node_namespace}) do
     node_identifier = "#{node_namespace}/#{node_name}"
 
-    GenServer.start_link(__MODULE__, {node, node_identifier},
-      name: {:global, node_identifier}
-    )
+    GenServer.start_link(__MODULE__, {node, node_identifier}, name: {:global, node_identifier})
   end
 
   def start_link({node, node_name, node_namespace, :executor_setting, {queue_length}}) do
@@ -36,7 +36,9 @@ defmodule Rclex.Node do
     )
   end
 
-  def start_link({node, node_name, node_namespace, :executor_setting, {queue_length, change_order}}) do
+  def start_link(
+        {node, node_name, node_namespace, :executor_setting, {queue_length, change_order}}
+      ) do
     node_identifier = "#{node_namespace}/#{node_name}"
 
     GenServer.start_link(__MODULE__, {node, node_identifier, queue_length, change_order},

--- a/lib/rclex/resource_server.ex
+++ b/lib/rclex/resource_server.ex
@@ -37,7 +37,7 @@ defmodule Rclex.ResourceServer do
     GenServer.call(ResourceServer, {:create_singlenode, {context, node_name}})
   end
 
-   @doc """
+  @doc """
       エグゼキュータの設定をしたノードをひとつだけ作成
       名前空間の有無を設定可能
       返り値:
@@ -46,19 +46,39 @@ defmodule Rclex.ResourceServer do
   """
 
   def create_singlenode_with_executor_setting(context, node_name, {queue_length}) do
-    GenServer.call(ResourceServer, {:create_singlenode_with_executor_setting, {context, node_name, {queue_length}}})
+    GenServer.call(
+      ResourceServer,
+      {:create_singlenode_with_executor_setting, {context, node_name, {queue_length}}}
+    )
   end
 
   def create_singlenode_with_executor_setting(context, node_name, {queue_length, change_order}) do
-    GenServer.call(ResourceServer, {:create_singlenode_with_executor_setting, {context, node_name, {queue_length, change_order}}})
+    GenServer.call(
+      ResourceServer,
+      {:create_singlenode_with_executor_setting,
+       {context, node_name, {queue_length, change_order}}}
+    )
   end
 
   def create_singlenode_with_executor_setting(context, node_name, node_name_space, {queue_length}) do
-    GenServer.call(ResourceServer, {:create_singlenode_with_executor_setting, {context, node_name, node_name_space, {queue_length}}})
+    GenServer.call(
+      ResourceServer,
+      {:create_singlenode_with_executor_setting,
+       {context, node_name, node_name_space, {queue_length}}}
+    )
   end
 
-  def create_singlenode_with_executor_setting(context, node_name, node_name_space, {queue_length, change_order}) do
-    GenServer.call(ResourceServer, {:create_singlenode_with_executor_setting, {context, node_name, node_name_space, {queue_length, change_order}}})
+  def create_singlenode_with_executor_setting(
+        context,
+        node_name,
+        node_name_space,
+        {queue_length, change_order}
+      ) do
+    GenServer.call(
+      ResourceServer,
+      {:create_singlenode_with_executor_setting,
+       {context, node_name, node_name_space, {queue_length, change_order}}}
+    )
   end
 
   @doc """
@@ -77,19 +97,51 @@ defmodule Rclex.ResourceServer do
   end
 
   def create_nodes_with_executor_setting(context, node_name, num_node, {queue_length}) do
-    GenServer.call(ResourceServer, {:create_nodes_with_executor_setting, {context, node_name, num_node, {queue_length}}})
+    GenServer.call(
+      ResourceServer,
+      {:create_nodes_with_executor_setting, {context, node_name, num_node, {queue_length}}}
+    )
   end
 
-  def create_nodes_with_executor_setting(context, node_name, num_node, {queue_length, change_order}) do
-    GenServer.call(ResourceServer, {:create_nodes_with_executor_setting, {context, node_name, num_node, {queue_length, change_order}}})
+  def create_nodes_with_executor_setting(
+        context,
+        node_name,
+        num_node,
+        {queue_length, change_order}
+      ) do
+    GenServer.call(
+      ResourceServer,
+      {:create_nodes_with_executor_setting,
+       {context, node_name, num_node, {queue_length, change_order}}}
+    )
   end
 
-  def create_nodes_with_executor_setting(context, node_name, node_name_space, num_node, {queue_length}) do
-    GenServer.call(ResourceServer, {:create_nodes_with_executor_setting, {context, node_name, node_name_space, num_node, {queue_length}}})
+  def create_nodes_with_executor_setting(
+        context,
+        node_name,
+        node_name_space,
+        num_node,
+        {queue_length}
+      ) do
+    GenServer.call(
+      ResourceServer,
+      {:create_nodes_with_executor_setting,
+       {context, node_name, node_name_space, num_node, {queue_length}}}
+    )
   end
 
-  def create_nodes_with_executor_setting(context, node_name, node_name_space, num_node, {queue_length, change_order}) do
-    GenServer.call(ResourceServer, {:create_nodes_with_executor_setting, {context, node_name, node_name_space, num_node, {queue_length, change_order}}})
+  def create_nodes_with_executor_setting(
+        context,
+        node_name,
+        node_name_space,
+        num_node,
+        {queue_length, change_order}
+      ) do
+    GenServer.call(
+      ResourceServer,
+      {:create_nodes_with_executor_setting,
+       {context, node_name, node_name_space, num_node, {queue_length, change_order}}}
+    )
   end
 
   def create_timer(call_back, args, time, timer_name) do
@@ -101,19 +153,47 @@ defmodule Rclex.ResourceServer do
   end
 
   def create_timer_with_executor_setting(call_back, args, time, timer_name, {queue_length}) do
-    GenServer.call(ResourceServer, {:create_timer_with_executor_setting, {call_back, args, time, timer_name, {queue_length}}})
+    GenServer.call(
+      ResourceServer,
+      {:create_timer_with_executor_setting, {call_back, args, time, timer_name, {queue_length}}}
+    )
   end
 
-  def create_timer_with_executor_setting(call_back, args, time, timer_name, {queue_length, change_order}) do
-    GenServer.call(ResourceServer, {:create_timer_with_executor_setting, {call_back, args, time, timer_name, {queue_length, change_order}}})
+  def create_timer_with_executor_setting(
+        call_back,
+        args,
+        time,
+        timer_name,
+        {queue_length, change_order}
+      ) do
+    GenServer.call(
+      ResourceServer,
+      {:create_timer_with_executor_setting,
+       {call_back, args, time, timer_name, {queue_length, change_order}}}
+    )
   end
 
   def create_timer_with_executor_setting(call_back, args, time, timer_name, limit, {queue_length}) do
-    GenServer.call(ResourceServer, {:create_timer_with_executor_setting, {call_back, args, time, timer_name, limit, {queue_length}}})
+    GenServer.call(
+      ResourceServer,
+      {:create_timer_with_executor_setting,
+       {call_back, args, time, timer_name, limit, {queue_length}}}
+    )
   end
 
-  def create_timer_with_executor_setting(call_back, args, time, timer_name, limit, {queue_length, change_order}) do
-    GenServer.call(ResourceServer, {:create_timer_with_executor_setting, {call_back, args, time, timer_name, limit, {queue_length, change_order}}})
+  def create_timer_with_executor_setting(
+        call_back,
+        args,
+        time,
+        timer_name,
+        limit,
+        {queue_length, change_order}
+      ) do
+    GenServer.call(
+      ResourceServer,
+      {:create_timer_with_executor_setting,
+       {call_back, args, time, timer_name, limit, {queue_length, change_order}}}
+    )
   end
 
   @doc """
@@ -185,7 +265,12 @@ defmodule Rclex.ResourceServer do
     end
   end
 
-  def handle_call({:create_singlenode_with_executor_setting, {context, node_name, node_namespace, executor_settings}}, _from, {resources}) do
+  def handle_call(
+        {:create_singlenode_with_executor_setting,
+         {context, node_name, node_namespace, executor_settings}},
+        _from,
+        {resources}
+      ) do
     if Map.has_key?(resources, {node_namespace, node_name}) do
       # 同名のノードがすでに存在しているときはエラーを返す
       {:reply, {:error, node_name}}
@@ -206,7 +291,11 @@ defmodule Rclex.ResourceServer do
     end
   end
 
-  def handle_call({:create_singlenode_with_executor_setting, {context, node_name, executor_settings}}, _from, {resources}) do
+  def handle_call(
+        {:create_singlenode_with_executor_setting, {context, node_name, executor_settings}},
+        _from,
+        {resources}
+      ) do
     if Map.has_key?(resources, {"", node_name}) do
       # 同名のノードがすでに存在しているときはエラーを返す
       {:reply, {:error, node_name}}
@@ -320,7 +409,12 @@ defmodule Rclex.ResourceServer do
     {:reply, {:ok, name_list}, {new_resources}}
   end
 
-  def handle_call({:create_nodes_with_executor_setting, {context, node_name, namespace, num_node, executor_settings}}, _from, {resources}) do
+  def handle_call(
+        {:create_nodes_with_executor_setting,
+         {context, node_name, namespace, num_node, executor_settings}},
+        _from,
+        {resources}
+      ) do
     name_list =
       Enum.map(0..(num_node - 1), fn n ->
         node_name ++ Integer.to_charlist(n)
@@ -371,7 +465,11 @@ defmodule Rclex.ResourceServer do
     {:reply, {:ok, node_identifier_list}, {new_resources}}
   end
 
-  def handle_call({:create_nodes_with_executor_setting, {context, node_name, num_node, executor_settings}}, _from, {resources}) do
+  def handle_call(
+        {:create_nodes_with_executor_setting, {context, node_name, num_node, executor_settings}},
+        _from,
+        {resources}
+      ) do
     name_list =
       Enum.map(0..(num_node - 1), fn n ->
         node_name ++ Integer.to_charlist(n)
@@ -454,7 +552,12 @@ defmodule Rclex.ResourceServer do
     end
   end
 
-  def handle_call({:create_timer_with_executor_setting, {call_back, args, time, timer_name, executor_settings}}, _from, {resources}) do
+  def handle_call(
+        {:create_timer_with_executor_setting,
+         {call_back, args, time, timer_name, executor_settings}},
+        _from,
+        {resources}
+      ) do
     timer_identifier = "#{timer_name}/Timer"
 
     if Map.has_key?(resources, {"", timer_identifier}) do
@@ -472,7 +575,12 @@ defmodule Rclex.ResourceServer do
     end
   end
 
-  def handle_call({:create_timer_with_executor_setting, {call_back, args, time, timer_name, limit, executor_settings}}, _from, {resources}) do
+  def handle_call(
+        {:create_timer_with_executor_setting,
+         {call_back, args, time, timer_name, limit, executor_settings}},
+        _from,
+        {resources}
+      ) do
     timer_identifier = "#{timer_name}/Timer"
 
     if Map.has_key?(resources, {"", timer_identifier}) do
@@ -480,7 +588,8 @@ defmodule Rclex.ResourceServer do
       {:reply, {:error, timer_name}}
     else
       children = [
-        {Rclex.Timer, {call_back, args, time, timer_name, limit, :executor_setting, executor_settings}}
+        {Rclex.Timer,
+         {call_back, args, time, timer_name, limit, :executor_setting, executor_settings}}
       ]
 
       opts = [strategy: :one_for_one]

--- a/lib/rclex/resource_server.ex
+++ b/lib/rclex/resource_server.ex
@@ -37,6 +37,30 @@ defmodule Rclex.ResourceServer do
     GenServer.call(ResourceServer, {:create_singlenode, {context, node_name}})
   end
 
+   @doc """
+      エグゼキュータの設定をしたノードをひとつだけ作成
+      名前空間の有無を設定可能
+      返り値:
+          node_identifier :: string()
+          作成したノードプロセスのnameを返す
+  """
+
+  def create_singlenode_with_executor_setting(context, node_name, {queue_length}) do
+    GenServer.call(ResourceServer, {:create_singlenode_with_executor_setting, {context, node_name, {queue_length}}})
+  end
+
+  def create_singlenode_with_executor_setting(context, node_name, {queue_length, change_order}) do
+    GenServer.call(ResourceServer, {:create_singlenode_with_executor_setting, {context, node_name, {queue_length, change_order}}})
+  end
+
+  def create_singlenode_with_executor_setting(context, node_name, node_name_space, {queue_length}) do
+    GenServer.call(ResourceServer, {:create_singlenode_with_executor_setting, {context, node_name, node_name_space, {queue_length}}})
+  end
+
+  def create_singlenode_with_executor_setting(context, node_name, node_name_space, {queue_length, change_order}) do
+    GenServer.call(ResourceServer, {:create_singlenode_with_executor_setting, {context, node_name, node_name_space, {queue_length, change_order}}})
+  end
+
   @doc """
       複数ノード生成
       create_nodes/4ではcreate_nodes/3に加えて名前空間の指定が可能
@@ -45,11 +69,27 @@ defmodule Rclex.ResourceServer do
           作成したノードプロセスのnameのリストを返す
   """
   def create_nodes(context, node_name, namespace, num_node) do
-    GenServer.call(ResourceServer, {:create_nodes, context, node_name, namespace, num_node})
+    GenServer.call(ResourceServer, {:create_nodes, {context, node_name, namespace, num_node}})
   end
 
   def create_nodes(context, node_name, num_node) do
-    GenServer.call(ResourceServer, {:create_nodes, context, node_name, num_node})
+    GenServer.call(ResourceServer, {:create_nodes, {context, node_name, num_node}})
+  end
+
+  def create_nodes_with_executor_setting(context, node_name, num_node, {queue_length}) do
+    GenServer.call(ResourceServer, {:create_nodes_with_executor_setting, {context, node_name, num_node, {queue_length}}})
+  end
+
+  def create_nodes_with_executor_setting(context, node_name, num_node, {queue_length, change_order}) do
+    GenServer.call(ResourceServer, {:create_nodes_with_executor_setting, {context, node_name, num_node, {queue_length, change_order}}})
+  end
+
+  def create_nodes_with_executor_setting(context, node_name, node_name_space, num_node, {queue_length}) do
+    GenServer.call(ResourceServer, {:create_nodes_with_executor_setting, {context, node_name, node_name_space, num_node, {queue_length}}})
+  end
+
+  def create_nodes_with_executor_setting(context, node_name, node_name_space, num_node, {queue_length, change_order}) do
+    GenServer.call(ResourceServer, {:create_nodes_with_executor_setting, {context, node_name, node_name_space, num_node, {queue_length, change_order}}})
   end
 
   def create_timer(call_back, args, time, timer_name) do
@@ -58,6 +98,22 @@ defmodule Rclex.ResourceServer do
 
   def create_timer(call_back, args, time, timer_name, limit) do
     GenServer.call(ResourceServer, {:create_timer, {call_back, args, time, timer_name, limit}})
+  end
+
+  def create_timer_with_executor_setting(call_back, args, time, timer_name, {queue_length}) do
+    GenServer.call(ResourceServer, {:create_timer_with_executor_setting, {call_back, args, time, timer_name, {queue_length}}})
+  end
+
+  def create_timer_with_executor_setting(call_back, args, time, timer_name, {queue_length, change_order}) do
+    GenServer.call(ResourceServer, {:create_timer_with_executor_setting, {call_back, args, time, timer_name, {queue_length, change_order}}})
+  end
+
+  def create_timer_with_executor_setting(call_back, args, time, timer_name, limit, {queue_length}) do
+    GenServer.call(ResourceServer, {:create_timer_with_executor_setting, {call_back, args, time, timer_name, limit, {queue_length}}})
+  end
+
+  def create_timer_with_executor_setting(call_back, args, time, timer_name, limit, {queue_length, change_order}) do
+    GenServer.call(ResourceServer, {:create_timer_with_executor_setting, {call_back, args, time, timer_name, limit, {queue_length, change_order}}})
   end
 
   @doc """
@@ -129,7 +185,48 @@ defmodule Rclex.ResourceServer do
     end
   end
 
-  def handle_call({:create_nodes, context, node_name, namespace, num_node}, _from, {resources}) do
+  def handle_call({:create_singlenode_with_executor_setting, {context, node_name, node_namespace, executor_settings}}, _from, {resources}) do
+    if Map.has_key?(resources, {node_namespace, node_name}) do
+      # 同名のノードがすでに存在しているときはエラーを返す
+      {:reply, {:error, node_name}}
+    else
+      node = Nifs.rcl_get_zero_initialized_node()
+      node_op = Nifs.rcl_node_get_default_options()
+      Nifs.rcl_node_init(node, node_name, node_namespace, context, node_op)
+
+      children = [
+        {Rclex.Node, {node, node_name, node_namespace, :executor_setting, executor_settings}}
+      ]
+
+      opts = [strategy: :one_for_one]
+      {:ok, pid} = Supervisor.start_link(children, opts)
+      node_identifier = "#{node_namespace}/#{node_name}"
+      new_resources = Map.put_new(resources, node_identifier, %{supervisor_id: pid})
+      {:reply, {:ok, node_identifier}, {new_resources}}
+    end
+  end
+
+  def handle_call({:create_singlenode_with_executor_setting, {context, node_name, executor_settings}}, _from, {resources}) do
+    if Map.has_key?(resources, {"", node_name}) do
+      # 同名のノードがすでに存在しているときはエラーを返す
+      {:reply, {:error, node_name}}
+    else
+      node = Nifs.rcl_get_zero_initialized_node()
+      node_op = Nifs.rcl_node_get_default_options()
+      Nifs.rcl_node_init_without_namespace(node, node_name, context, node_op)
+
+      children = [
+        {Rclex.Node, {node, node_name, :executor_setting, executor_settings}}
+      ]
+
+      opts = [strategy: :one_for_one]
+      {:ok, pid} = Supervisor.start_link(children, opts)
+      new_resources = Map.put_new(resources, node_name, %{supervisor_id: pid})
+      {:reply, {:ok, node_name}, {new_resources}}
+    end
+  end
+
+  def handle_call({:create_nodes, {context, node_name, namespace, num_node}}, _from, {resources}) do
     name_list =
       Enum.map(0..(num_node - 1), fn n ->
         node_name ++ Integer.to_charlist(n)
@@ -178,7 +275,7 @@ defmodule Rclex.ResourceServer do
     {:reply, {:ok, node_identifier_list}, {new_resources}}
   end
 
-  def handle_call({:create_nodes, context, node_name, num_node}, _from, {resources}) do
+  def handle_call({:create_nodes, {context, node_name, num_node}}, _from, {resources}) do
     name_list =
       Enum.map(0..(num_node - 1), fn n ->
         node_name ++ Integer.to_charlist(n)
@@ -203,6 +300,104 @@ defmodule Rclex.ResourceServer do
               {
                 Enum.at(node_list, n),
                 Enum.at(name_list, n)
+              }
+            }
+          ],
+          strategy: :one_for_one
+        )
+      end)
+      |> Enum.map(fn {:ok, pid} -> pid end)
+
+    nodes_list =
+      Enum.map(0..(num_node - 1), fn n ->
+        node_name = Enum.at(name_list, n)
+        pid = Enum.at(id_list, n)
+        {node_name, %{supervisor_id: pid}}
+      end)
+
+    new_resources = for {k, v} <- nodes_list, into: resources, do: {k, v}
+
+    {:reply, {:ok, name_list}, {new_resources}}
+  end
+
+  def handle_call({:create_nodes_with_executor_setting, {context, node_name, namespace, num_node, executor_settings}}, _from, {resources}) do
+    name_list =
+      Enum.map(0..(num_node - 1), fn n ->
+        node_name ++ Integer.to_charlist(n)
+      end)
+
+    node_list =
+      Enum.map(0..(num_node - 1), fn n ->
+        Nifs.rcl_node_init(
+          Nifs.rcl_get_zero_initialized_node(),
+          Enum.at(name_list, n),
+          namespace,
+          context,
+          Nifs.rcl_node_get_default_options()
+        )
+      end)
+
+    id_list =
+      Enum.map(0..(num_node - 1), fn n ->
+        Supervisor.start_link(
+          [
+            {
+              Rclex.Node,
+              {
+                Enum.at(node_list, n),
+                Enum.at(name_list, n),
+                namespace,
+                :executor_setting,
+                executor_settings
+              }
+            }
+          ],
+          strategy: :one_for_one
+        )
+      end)
+      |> Enum.map(fn {:ok, pid} -> pid end)
+
+    node_identifier_list = Enum.map(name_list, fn name -> "#{namespace}/#{name}" end)
+
+    nodes_list =
+      Enum.map(0..(num_node - 1), fn n ->
+        node_identifier = Enum.at(node_identifier_list, n)
+        pid = Enum.at(id_list, n)
+        {node_identifier, %{supervisor_id: pid}}
+      end)
+
+    new_resources = for {k, v} <- nodes_list, into: resources, do: {k, v}
+
+    {:reply, {:ok, node_identifier_list}, {new_resources}}
+  end
+
+  def handle_call({:create_nodes_with_executor_setting, {context, node_name, num_node, executor_settings}}, _from, {resources}) do
+    name_list =
+      Enum.map(0..(num_node - 1), fn n ->
+        node_name ++ Integer.to_charlist(n)
+      end)
+
+    node_list =
+      Enum.map(0..(num_node - 1), fn n ->
+        Nifs.rcl_node_init_without_namespace(
+          Nifs.rcl_get_zero_initialized_node(),
+          Enum.at(name_list, n),
+          context,
+          Nifs.rcl_node_get_default_options()
+        )
+      end)
+
+    id_list =
+      Enum.map(0..(num_node - 1), fn n ->
+        Supervisor.start_link(
+          [
+            {
+              Rclex.Node,
+              {
+                Enum.at(node_list, n),
+                Enum.at(name_list, n),
+                :executor_setting,
+                executor_settings
               }
             }
           ],
@@ -250,6 +445,42 @@ defmodule Rclex.ResourceServer do
     else
       children = [
         {Rclex.Timer, {call_back, args, time, timer_name, limit}}
+      ]
+
+      opts = [strategy: :one_for_one]
+      {:ok, pid} = Supervisor.start_link(children, opts)
+      new_resources = Map.put_new(resources, timer_identifier, %{supervisor_id: pid})
+      {:reply, {:ok, timer_identifier}, {new_resources}}
+    end
+  end
+
+  def handle_call({:create_timer_with_executor_setting, {call_back, args, time, timer_name, executor_settings}}, _from, {resources}) do
+    timer_identifier = "#{timer_name}/Timer"
+
+    if Map.has_key?(resources, {"", timer_identifier}) do
+      # 同名のノードがすでに存在しているときはエラーを返す
+      {:reply, {:error, timer_name}}
+    else
+      children = [
+        {Rclex.Timer, {call_back, args, time, timer_name, :executor_setting, executor_settings}}
+      ]
+
+      opts = [strategy: :one_for_one]
+      {:ok, pid} = Supervisor.start_link(children, opts)
+      new_resources = Map.put_new(resources, timer_identifier, %{supervisor_id: pid})
+      {:reply, {:ok, timer_identifier}, {new_resources}}
+    end
+  end
+
+  def handle_call({:create_timer_with_executor_setting, {call_back, args, time, timer_name, limit, executor_settings}}, _from, {resources}) do
+    timer_identifier = "#{timer_name}/Timer"
+
+    if Map.has_key?(resources, {"", timer_identifier}) do
+      # 同名のノードがすでに存在しているときはエラーを返す
+      {:reply, {:error, timer_name}}
+    else
+      children = [
+        {Rclex.Timer, {call_back, args, time, timer_name, limit, :executor_setting, executor_settings}}
       ]
 
       opts = [strategy: :one_for_one]

--- a/lib/rclex/timer.ex
+++ b/lib/rclex/timer.ex
@@ -19,11 +19,25 @@ defmodule Rclex.Timer do
     )
   end
 
+  def start_link({callback, args, time, timer_name, :executor_setting, executor_settings}) do
+    GenServer.start_link(__MODULE__, {callback, args, time, timer_name, :executor_setting, executor_settings},
+      name: {:global, "#{timer_name}/Timer"}
+    )
+  end
+
+  def start_link({callback, args, time, timer_name, limit, :executor_setting, executor_settings}) do
+    GenServer.start_link(__MODULE__, {callback, args, time, timer_name, limit, :executor_setting, executor_settings},
+      name: {:global, "#{timer_name}/Timer"}
+    )
+  end
+
   # callback: コールバック関数
   # args: コールバック関数に渡す引数
   # time: 周期。ミリ秒で指定。
   # count: 現在何回目の実行か。初期値は0。
   # limit: 最大実行回数
+  # queue_length: エグゼキュータのキューの長さ
+  # change_order: ジョブの実行順序を変更する関数
   def init({callback, args, time, timer_name}) do
     job_children = [
       {Rclex.JobQueue, {timer_name}},
@@ -46,6 +60,80 @@ defmodule Rclex.Timer do
     job_children = [
       {Rclex.JobQueue, {timer_name}},
       {Rclex.JobExecutor, {timer_name}}
+    ]
+
+    opts = [strategy: :one_for_one]
+    {:ok, job_supervisor_id} = Supervisor.start_link(job_children, opts)
+
+    children = [
+      {Rclex.TimerLoop, {timer_name, time, limit}}
+    ]
+
+    opts = [strategy: :one_for_one]
+    {:ok, loop_supervisor_id} = Supervisor.start_link(children, opts)
+    {:ok, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
+  end
+
+  def init({callback, args, time, timer_name, :executor_setting, {queue_length}}) do
+    job_children = [
+      {Rclex.JobQueue, {timer_name, queue_length}},
+      {Rclex.JobExecutor, {timer_name}}
+    ]
+
+    opts = [strategy: :one_for_one]
+    {:ok, job_supervisor_id} = Supervisor.start_link(job_children, opts)
+
+    children = [
+      {Rclex.TimerLoop, {timer_name, time}}
+    ]
+
+    opts = [strategy: :one_for_one]
+    {:ok, loop_supervisor_id} = Supervisor.start_link(children, opts)
+    {:ok, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
+  end
+
+  def init({callback, args, time, timer_name, :executor_setting, {queue_length, change_order}}) do
+    job_children = [
+      {Rclex.JobQueue, {timer_name, queue_length}},
+      {Rclex.JobExecutor, {timer_name, change_order}}
+    ]
+
+    Logger.debug(change_order.("timer"))
+
+    opts = [strategy: :one_for_one]
+    {:ok, job_supervisor_id} = Supervisor.start_link(job_children, opts)
+
+    children = [
+      {Rclex.TimerLoop, {timer_name, time}}
+    ]
+
+    opts = [strategy: :one_for_one]
+    {:ok, loop_supervisor_id} = Supervisor.start_link(children, opts)
+    {:ok, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
+  end
+
+  def init({callback, args, time, timer_name, limit, :executor_setting, {queue_length}}) do
+    job_children = [
+      {Rclex.JobQueue, {timer_name, queue_length}},
+      {Rclex.JobExecutor, {timer_name}}
+    ]
+
+    opts = [strategy: :one_for_one]
+    {:ok, job_supervisor_id} = Supervisor.start_link(job_children, opts)
+
+    children = [
+      {Rclex.TimerLoop, {timer_name, time, limit}}
+    ]
+
+    opts = [strategy: :one_for_one]
+    {:ok, loop_supervisor_id} = Supervisor.start_link(children, opts)
+    {:ok, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
+  end
+
+  def init({callback, args, time, timer_name, limit, :executor_setting, {queue_length, change_order}}) do
+    job_children = [
+      {Rclex.JobQueue, {timer_name, queue_length}},
+      {Rclex.JobExecutor, {timer_name, change_order}}
     ]
 
     opts = [strategy: :one_for_one]

--- a/lib/rclex/timer.ex
+++ b/lib/rclex/timer.ex
@@ -20,13 +20,17 @@ defmodule Rclex.Timer do
   end
 
   def start_link({callback, args, time, timer_name, :executor_setting, executor_settings}) do
-    GenServer.start_link(__MODULE__, {callback, args, time, timer_name, :executor_setting, executor_settings},
+    GenServer.start_link(
+      __MODULE__,
+      {callback, args, time, timer_name, :executor_setting, executor_settings},
       name: {:global, "#{timer_name}/Timer"}
     )
   end
 
   def start_link({callback, args, time, timer_name, limit, :executor_setting, executor_settings}) do
-    GenServer.start_link(__MODULE__, {callback, args, time, timer_name, limit, :executor_setting, executor_settings},
+    GenServer.start_link(
+      __MODULE__,
+      {callback, args, time, timer_name, limit, :executor_setting, executor_settings},
       name: {:global, "#{timer_name}/Timer"}
     )
   end
@@ -130,7 +134,9 @@ defmodule Rclex.Timer do
     {:ok, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
   end
 
-  def init({callback, args, time, timer_name, limit, :executor_setting, {queue_length, change_order}}) do
+  def init(
+        {callback, args, time, timer_name, limit, :executor_setting, {queue_length, change_order}}
+      ) do
     job_children = [
       {Rclex.JobQueue, {timer_name, queue_length}},
       {Rclex.JobExecutor, {timer_name, change_order}}


### PR DESCRIPTION
creaete_nodeとcreate_timerにexecutorのキューの長さと実行順序を設定できるapiを追加しました．