### PR TITLE
Release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v0.5.3 on 18 Feb 2022
+## v0.5.3 on 22 Feb 2022
 
 - New features:
   - Add following APIs #92 
@@ -11,7 +11,7 @@
     - `create_nodes_with_executor_setting/4`, `create_timer_with_executor_setting/5` and `create_timer_with_executor_setting/6`: same with the above
 - Code Improvements/Fixes: none
 - Bumps:
-  - `ex_doc` to 0.28.0 #90
+  - `ex_doc` to 0.28.1 #96
   - `credo` to 1.6.3 #91
 - Known issues:
   - `mix test` sometimes fails, but we don't think it will affect the behavior #68

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## v0.5.3 on 18 Feb 2022
+
+- New features:
+  - Add following APIs #92 
+    - `create_singlenode_with_executor_setting/3`
+      - can specify `executor_setting` in addition to args in `create_singlenode/3`
+      - `{queue_length}` means the maximum length of `job_queue` under the created nodes
+      - `change_order` (in `{queue_length, change_order}`) means a function that adjusts the execution order of `job_exe`
+    - `create_nodes_with_executor_setting/4`, `create_timer_with_executor_setting/5` and `create_timer_with_executor_setting/6`: same with the above
+- Code Improvements/Fixes: none
+- Bumps:
+  - `ex_doc` to 0.28.0 #90
+  - `credo` to 1.6.3 #91
+- Known issues:
+  - `mix test` sometimes fails, but we don't think it will affect the behavior #68
+- Full Changelog: https://github.com/rclex/rclex/compare/v0.5.2...v0.5.3
+
 ## v0.5.2 on 21 Jan 2022
 
 - New features:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:rclex, "~> 0.5.2"}
+    {:rclex, "~> 0.5.3"}
   ]
 end
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -56,7 +56,7 @@ ROSからの大きな違いとして，通信にDDS（Data Distribution Service�
 ```elixir
 def deps do
   [
-    {:rclex, "~> 0.5.2"}
+    {:rclex, "~> 0.5.3"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Rclex.MixProject do
   ROS 2 Client Library for Elixir.
   """
 
-  @version "0.5.2"
+  @version "0.5.3"
   @source_url "https://github.com/rclex/rclex"
 
   def project do


### PR DESCRIPTION
## v0.5.3 on 18 Feb 2022

- New features:
  - Add following APIs #92 
    - `create_singlenode_with_executor_setting/3`
      - can specify `executor_setting` in addition to args in `create_singlenode/3`
      - `{queue_length}` means the maximum length of `job_queue` under the created nodes
      - `change_order` (in `{queue_length, change_order}`) means a function that adjusts the execution order of `job_exe`
    - `create_nodes_with_executor_setting/4`, `create_timer_with_executor_setting/5` and `create_timer_with_executor_setting/6`: same with the above
- Code Improvements/Fixes: none
- Bumps:
  - `ex_doc` to 0.28.0 #90
  - `credo` to 1.6.3 #91
- Known issues:
  - `mix test` sometimes fails, but we don't think it will affect the behavior #68
- Full Changelog: https://github.com/rclex/rclex/compare/v0.5.2...v0.5.3