### PR TITLE
release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## v0.6.0 on 17 Mar 2022
+
+- New features:
+  - support custom msgtype!! #87 #98
+- Code Improvements/Fixes:
+  - Enhance README #102
+- Bumps:
+  - `ex_doc` to 0.28.2 #99
+  - `credo` to 1.6.4 #100
+- Known issues:
+  - `rclex_connection_tests` becomes failed on Dashing from v0.6.0_rc #89
+- Full Changelog: https://github.com/rclex/rclex/compare/v0.5.3...v0.6.0
+
 ## v0.5.3 on 22 Feb 2022
 
 - New features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - `credo` to 1.6.4 #100
 - Known issues:
   - `rclex_connection_tests` becomes failed on Dashing from v0.6.0_rc #89
+  - `Rclex.initialize_msg/0` is undefined or private in `KeepSub.sub_task_start/2` #104
 - Full Changelog: https://github.com/rclex/rclex/compare/v0.5.3...v0.6.0
 
 ## v0.5.3 on 22 Feb 2022

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:rclex, "~> 0.5.3"}
+    {:rclex, "~> 0.6.0"}
   ]
 end
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -47,7 +47,7 @@ ROSからの大きな違いとして，通信にDDS（Data Distribution Service�
 ```elixir
 def deps do
   [
-    {:rclex, "~> 0.5.3"}
+    {:rclex, "~> 0.6.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Rclex.MixProject do
   ROS 2 Client Library for Elixir.
   """
 
-  @version "0.5.3"
+  @version "0.6.0"
   @source_url "https://github.com/rclex/rclex"
 
   def project do


### PR DESCRIPTION
## v0.6.0 on 17 Mar 2022

- New features:
  - support custom msgtype!! #87 #98
- Code Improvements/Fixes:
  - Enhance README #102
- Bumps:
  - `ex_doc` to 0.28.2 #99
  - `credo` to 1.6.4 #100
- Known issues:
  - `rclex_connection_tests` becomes failed on Dashing from v0.6.0_rc #89
- Full Changelog: https://github.com/rclex/rclex/compare/v0.5.3...v0.6.0