### PR TITLE
release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## v0.6.2 on 25 May 2022
+
+* New features: none
+* Code Improvements/Fixes:
+  * Add simple pub sub test by @s-hosoai in https://github.com/rclex/rclex/pull/113
+  * fix job_queue length condition (fix #112) by @s-hosoai in https://github.com/rclex/rclex/pull/115
+  * remove Dashing from CI targets by @takasehideki in https://github.com/rclex/rclex/pull/116
+* Bumps:
+  * `ex_doc` to 0.28.4 #110
+* Known issues:
+  * `rclex_connection_tests` becomes failed on Dashing from v0.6.0_rc #89
+  * `Rclex.initialize_msg/0` is undefined or private in `KeepSub.sub_task_start/2` #104
+* Full Changelog: https://github.com/rclex/rclex/compare/v0.6.1...v0.6.2
+
 ## v0.6.1 on 22 Mar 2022
 
 - New features: none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.6.2 on 25 May 2022
 
+* Please welcome @s-hosoai as a new maintainer!
 * New features: none
 * Code Improvements/Fixes:
   * Add simple pub sub test by @s-hosoai in https://github.com/rclex/rclex/pull/113

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:rclex, "~> 0.6.1"}
+    {:rclex, "~> 0.6.2"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -82,3 +82,4 @@ Please reference examples [here](https://github.com/rclex/rclex_examples). Also 
 - [@HiroiImanishi](https://github.com/HiroiImanishi)
 - [@kebus426](https://github.com/kebus426)
 - [@shiroro466](https://github.com/shiroro466)
+- [@s-hosoai](https://github.com/s-hosoai)

--- a/README_ja.md
+++ b/README_ja.md
@@ -69,3 +69,4 @@ end
 - [@HiroiImanishi](https://github.com/HiroiImanishi)
 - [@kebus426](https://github.com/kebus426)
 - [@shiroro466](https://github.com/shiroro466)
+- [@s-hosoai](https://github.com/s-hosoai)

--- a/README_ja.md
+++ b/README_ja.md
@@ -47,7 +47,7 @@ ROSからの大きな違いとして，通信にDDS（Data Distribution Service�
 ```elixir
 def deps do
   [
-    {:rclex, "~> 0.6.1"}
+    {:rclex, "~> 0.6.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Rclex.MixProject do
   ROS 2 Client Library for Elixir.
   """
 
-  @version "0.6.1"
+  @version "0.6.2"
   @source_url "https://github.com/rclex/rclex"
 
   def project do


### PR DESCRIPTION
## v0.6.2 on 25 May 2022

* Please welcome @s-hosoai as a new maintainer! :tada:
* New features: none
* Code Improvements/Fixes:
  * Add simple pub sub test by @s-hosoai in https://github.com/rclex/rclex/pull/113
  * fix job_queue length condition (fix #112) by @s-hosoai in https://github.com/rclex/rclex/pull/115
  * remove Dashing from CI targets by @takasehideki in https://github.com/rclex/rclex/pull/116
* Bumps:
  * `ex_doc` to 0.28.4 #110
* Known issues:
  * `rclex_connection_tests` becomes failed on Dashing from v0.6.0_rc #89
  * `Rclex.initialize_msg/0` is undefined or private in `KeepSub.sub_task_start/2` #104
* Full Changelog: https://github.com/rclex/rclex/compare/v0.6.1...v0.6.2
