### PR TITLE
Refactoring to simplify implementation

### DIFF
--- a/lib/rclex/job_executor.ex
+++ b/lib/rclex/job_executor.ex
@@ -18,16 +18,19 @@ defmodule Rclex.JobExecutor do
     )
   end
 
+  @impl GenServer
   def init({}) do
     Logger.debug("JobExecutor start")
     {:ok, {}}
   end
 
+  @impl GenServer
   def init({change_order}) do
     Logger.debug("JobExecutor start")
     {:ok, {change_order}}
   end
 
+  @impl GenServer
   def handle_cast({:execute, job_queue}, {}) do
     :queue.to_list(job_queue)
     |> Enum.map(fn {key, action, args} -> GenServer.cast(key, {action, args}) end)
@@ -35,6 +38,7 @@ defmodule Rclex.JobExecutor do
     {:noreply, {}}
   end
 
+  @impl GenServer
   def handle_cast({:execute, job_queue}, {change_order}) do
     job_list = :queue.to_list(job_queue)
 

--- a/lib/rclex/job_executor.ex
+++ b/lib/rclex/job_executor.ex
@@ -1,5 +1,4 @@
 defmodule Rclex.JobExecutor do
-  require Rclex.Macros
   require Logger
   use GenServer, restart: :transient
 

--- a/lib/rclex/job_queue.ex
+++ b/lib/rclex/job_queue.ex
@@ -1,5 +1,4 @@
 defmodule Rclex.JobQueue do
-  require Rclex.Macros
   require Logger
   use GenServer, restart: :transient
 

--- a/lib/rclex/job_queue.ex
+++ b/lib/rclex/job_queue.ex
@@ -38,13 +38,4 @@ defmodule Rclex.JobQueue do
       {:noreply, {target_identifier, queue_length, new_job_queue}}
     end
   end
-
-  # def handle_call(:pop, _from, {target_identifier, job_queue}) do
-  #   if :queue.len(job_queue) > 0 do
-  #     {{:value, job}, new_job_queue} = :queue.out(job_queue)
-  #     {:reply, {:exist_job, job}, new_job_queue}
-  #   else
-  #     {:reply, {:no_job, {}}, {target_identifier, job_queue}}
-  #   end
-  # end
 end

--- a/lib/rclex/job_queue.ex
+++ b/lib/rclex/job_queue.ex
@@ -23,10 +23,12 @@ defmodule Rclex.JobQueue do
     )
   end
 
+  @impl GenServer
   def init({target_identifier, queue_length}) do
     {:ok, {target_identifier, queue_length, :queue.new()}}
   end
 
+  @impl GenServer
   def handle_cast({:push, job}, {target_identifier, queue_length, job_queue}) do
     new_job_queue = :queue.in(job, job_queue)
 

--- a/lib/rclex/keep_sub.ex
+++ b/lib/rclex/keep_sub.ex
@@ -1,6 +1,6 @@
 defmodule Rclex.KeepSub do
   alias Rclex.Nifs
-  require Rclex.Macros
+  require Rclex.ReturnCode
   require Logger
 
   @moduledoc """
@@ -10,13 +10,13 @@ defmodule Rclex.KeepSub do
 
   def take_once(takemsg, sub, msginfo, sub_alloc, callback) do
     case Nifs.rcl_take(sub, takemsg, msginfo, sub_alloc) do
-      {Rclex.Macros.rcl_ret_ok(), _, _, _} ->
+      {Rclex.ReturnCode.rcl_ret_ok(), _, _, _} ->
         callback.(takemsg)
 
-      {Rclex.Macros.rcl_ret_subscription_invalid(), _, _, _} ->
+      {Rclex.ReturnCode.rcl_ret_subscription_invalid(), _, _, _} ->
         Logger.error("subscription invalid")
 
-      {Rclex.Macros.rcl_ret_subscription_take_failed(), _, _, _} ->
+      {Rclex.ReturnCode.rcl_ret_subscription_take_failed(), _, _, _} ->
         do_nothing()
     end
   end

--- a/lib/rclex/nifs.ex
+++ b/lib/rclex/nifs.ex
@@ -13,19 +13,19 @@ defmodule Rclex.Nifs do
   # -----------------------init_nif.c--------------------------
 
   def rcl_get_zero_initialized_init_options do
-    raise "NIF rcl_get_zero_initialized_init_options/0 not implemented"
+    :erlang.nif_error("NIF rcl_get_zero_initialized_init_options/0 not implemented")
   end
 
   def rcl_init_options_init(_a) do
-    raise "NIF rcl_init_options_init/1 is not implemented"
+    :erlang.nif_error("NIF rcl_init_options_init/1 is not implemented")
   end
 
   def rcl_init_options_fini(_a) do
-    raise "NIF rcl_init_options_fini/1 is not implemented"
+    :erlang.nif_error("NIF rcl_init_options_fini/1 is not implemented")
   end
 
   def rcl_get_zero_initialized_context do
-    raise "NIF rcl_get_zero_initialized_context/0 not implemented"
+    :erlang.nif_error("NIF rcl_get_zero_initialized_context/0 not implemented")
   end
 
   @doc """
@@ -38,7 +38,7 @@ defmodule Rclex.Nifs do
         argc,argvに0,NULLを直接入れる関数
   """
   def rcl_init_with_null(_a, _b) do
-    raise "NIF rcl_init_with_null/2 not implemented"
+    :erlang.nif_error("NIF rcl_init_with_null/2 not implemented")
   end
 
   @doc """
@@ -47,18 +47,18 @@ defmodule Rclex.Nifs do
           rcl_context_t)
   """
   def rcl_shutdown(_a) do
-    raise "NIF rcl_shutdown/1 not implemented"
+    :erlang.nif_error("NIF rcl_shutdown/1 not implemented")
   end
 
   # -----------------------node_nif.c--------------------------
   # return {:ok,rcl_node_t}
   def rcl_get_zero_initialized_node do
-    raise "NIF rcl_get_zero_initialized_node/0 not implemented"
+    :erlang.nif_error("NIF rcl_get_zero_initialized_node/0 not implemented")
   end
 
   # return {:ok,rcl_node_options_t}
   def rcl_node_get_default_options do
-    raise "NIF rcl_node_get_default_options/0 not implemented"
+    :erlang.nif_error("NIF rcl_node_get_default_options/0 not implemented")
   end
 
   @doc """
@@ -71,11 +71,11 @@ defmodule Rclex.Nifs do
       const rcl_node_options_t * options)
   """
   def rcl_node_init(_a, _b, _c, _d, _e) do
-    raise "NIF rcl_node_init/5 not implemented"
+    :erlang.nif_error("NIF rcl_node_init/5 not implemented")
   end
 
   def rcl_node_init_without_namespace(_a, _b, _c, _d) do
-    raise "NIF rcl_node_init_without_namespace/4 is not implemented"
+    :erlang.nif_error("NIF rcl_node_init_without_namespace/4 is not implemented")
   end
 
   @doc """
@@ -83,11 +83,11 @@ defmodule Rclex.Nifs do
       argument...rcl_node_t
   """
   def rcl_node_fini(_a) do
-    raise "NIF rcl_node_fini/1 not implemented"
+    :erlang.nif_error("NIF rcl_node_fini/1 not implemented")
   end
 
   def read_guard_condition(_a) do
-    raise "haha"
+    :erlang.nif_error("haha")
   end
 
   @doc """
@@ -95,7 +95,7 @@ defmodule Rclex.Nifs do
   """
 
   def rcl_node_get_name(_a) do
-    raise "NIF rcl_node_get_name/1 not implemented"
+    :erlang.nif_error("NIF rcl_node_get_name/1 not implemented")
   end
 
   # ------------------------------publisher_nif.c--------------------------
@@ -104,7 +104,7 @@ defmodule Rclex.Nifs do
       argument...void
   """
   def rcl_get_zero_initialized_publisher do
-    raise "NIF get_zero_initialized_publisher/0 not implemented"
+    :erlang.nif_error("NIF get_zero_initialized_publisher/0 not implemented")
   end
 
   @doc """
@@ -112,7 +112,7 @@ defmodule Rclex.Nifs do
       argument...void
   """
   def rcl_publisher_get_default_options do
-    raise "rcl_get_zero_initialized_publisher/0 not implemented"
+    :erlang.nif_error("rcl_get_zero_initialized_publisher/0 not implemented")
   end
 
   @doc """
@@ -120,7 +120,7 @@ defmodule Rclex.Nifs do
       argument...rcl_publisher_t*
   """
   def rcl_publisher_get_topic_name(_a) do
-    raise "rcl_get_zero_initialized_publisher/0 not implemented"
+    :erlang.nif_error("rcl_get_zero_initialized_publisher/0 not implemented")
   end
 
   @doc """
@@ -128,7 +128,7 @@ defmodule Rclex.Nifs do
       argument...rcl_publisher_t*,rcl_node_t*
   """
   def rcl_publisher_fini(_a, _b) do
-    raise "rcl_get_zero_initialized_publisher/0 not implemented"
+    :erlang.nif_error("rcl_get_zero_initialized_publisher/0 not implemented")
   end
 
   @doc """
@@ -140,7 +140,7 @@ defmodule Rclex.Nifs do
                   const rcl_publisher_options_t * options
   """
   def rcl_publisher_init(_a, _b, _c, _d, _e) do
-    raise "rcl_publisher_init/4 not implemented"
+    :erlang.nif_error("rcl_publisher_init/4 not implemented")
   end
 
   @doc """
@@ -148,7 +148,7 @@ defmodule Rclex.Nifs do
       argument...rcl_publisher_t*
   """
   def rcl_publisher_is_valid(_a) do
-    raise "rcl_publisher_is_valid/1 not implemented"
+    :erlang.nif_error("rcl_publisher_is_valid/1 not implemented")
   end
 
   @doc """
@@ -160,24 +160,24 @@ defmodule Rclex.Nifs do
     );
   """
   def rcl_publish(_a, _b, _c) do
-    raise "rcl_publish/3 is not implemented"
+    :erlang.nif_error("rcl_publish/3 is not implemented")
   end
 
   def create_pub_alloc do
-    raise "NIF create_pub_alloc/0 is not implemented"
+    :erlang.nif_error("NIF create_pub_alloc/0 is not implemented")
   end
 
   # ---------------------------subscription_nif.c--------------------------
   def rcl_subscription_get_default_options do
-    raise "NIF rcl_subscription_get_default_options is not implemented"
+    :erlang.nif_error("NIF rcl_subscription_get_default_options is not implemented")
   end
 
   def rcl_get_zero_initialized_subscription do
-    raise "NIF rcl_subscription_get_default_options is not implemented"
+    :erlang.nif_error("NIF rcl_subscription_get_default_options is not implemented")
   end
 
   def create_sub_alloc do
-    raise "NIF create_suballoc/0 is not implemented"
+    :erlang.nif_error("NIF create_suballoc/0 is not implemented")
   end
 
   @doc """
@@ -191,7 +191,7 @@ defmodule Rclex.Nifs do
   );
   """
   def rcl_subscription_init(_a, _b, _c, _d, _e) do
-    raise "NIF rcl_subscription_init is not implemented"
+    :erlang.nif_error("NIF rcl_subscription_init is not implemented")
   end
 
   @doc """
@@ -199,11 +199,11 @@ defmodule Rclex.Nifs do
       argument...rcl_subscription_t*,rcl_node_t*
   """
   def rcl_subscription_fini(_a, _b) do
-    raise "NIF rcl_subscription_fini is not implemented"
+    :erlang.nif_error("NIF rcl_subscription_fini is not implemented")
   end
 
   def rcl_subscription_get_topic_name(_a) do
-    raise "NIF rcl_subscription_get_topic_name/1 is not implemented"
+    :erlang.nif_error("NIF rcl_subscription_get_topic_name/1 is not implemented")
   end
 
   @doc """
@@ -216,7 +216,7 @@ defmodule Rclex.Nifs do
     );
   """
   def rcl_take(_a, _b, _c, _d) do
-    raise "NIF rcl_take is not implemented"
+    :erlang.nif_error("NIF rcl_take is not implemented")
   end
 
   # -----------------------------graph_nif.c------------------------------
@@ -229,85 +229,85 @@ defmodule Rclex.Nifs do
       rcl_names_and_types_t * topic_names_and_types);
   """
   def rcl_get_topic_names_and_types(_a, _b, _c) do
-    raise "NIF rcl_get_topic_names_and_types is not implemented"
+    :erlang.nif_error("NIF rcl_get_topic_names_and_types is not implemented")
   end
 
   # -----------------------------wait_nif.c------------------------------
   def rcl_get_default_allocator do
-    raise "NIF rcl_get_default_allocator/0 is not implemented"
+    :erlang.nif_error("NIF rcl_get_default_allocator/0 is not implemented")
   end
 
   def rcl_get_zero_initialized_wait_set do
-    raise "NIF rcl_get_zero_initialized_wait_set/0 is not implemented"
+    :erlang.nif_error("NIF rcl_get_zero_initialized_wait_set/0 is not implemented")
   end
 
   def rcl_wait_set_init(_a, _b, _c, _d, _e, _f, _g, _h, _i) do
-    raise "NIF rcl_wait_set_init/9 is not implemented"
+    :erlang.nif_error("NIF rcl_wait_set_init/9 is not implemented")
   end
 
   def rcl_wait_set_fini(_a) do
-    raise "NIF rcl_wait_set_fini/1 is not implemented"
+    :erlang.nif_error("NIF rcl_wait_set_fini/1 is not implemented")
   end
 
   def rcl_wait_set_clear(_a) do
-    raise "NIF rcl_wait_set_clear/1 is not implemented"
+    :erlang.nif_error("NIF rcl_wait_set_clear/1 is not implemented")
   end
 
   def rcl_wait_set_add_subscription(_a, _b) do
-    raise "NIF rcl_wait_set_add_subscription/2 is not implemented"
+    :erlang.nif_error("NIF rcl_wait_set_add_subscription/2 is not implemented")
   end
 
   def rcl_wait(_a, _b) do
-    raise "NIF rcl_wait/0 is not implemented"
+    :erlang.nif_error("NIF rcl_wait/0 is not implemented")
   end
 
   def check_subscription(_a) do
-    raise "NIF check_subscription/1 is not implemented"
+    :erlang.nif_error("NIF check_subscription/1 is not implemented")
   end
 
   def check_waitset(_a, _b) do
-    raise "NIF check_waitset/2 is not implemented"
+    :erlang.nif_error("NIF check_waitset/2 is not implemented")
   end
 
   def get_sublist_from_waitset(_a) do
-    raise "NIF get_sublist_from_waitset/1 is not implemented"
+    :erlang.nif_error("NIF get_sublist_from_waitset/1 is not implemented")
   end
 
   # ------------------------------msg_nif.c----------------------------
   def create_msginfo do
-    raise "NIF create_msginfo/0 is not implemented"
+    :erlang.nif_error("NIF create_msginfo/0 is not implemented")
   end
 
   # -----<custom_msgtype>_nif.c-----start-----
   def get_typesupport_geometry_msgs_msg_twist,
-    do: raise("NIF get_typesupport_geometry_msgs_msg_twist/0 is not implemented")
+    do: :erlang.nif_error("NIF get_typesupport_geometry_msgs_msg_twist/0 is not implemented")
 
   def create_empty_msg_geometry_msgs_msg_twist,
-    do: raise("NIF create_empty_msg_geometry_msgs_msg_twist/0 is not implemented")
+    do: :erlang.nif_error("NIF create_empty_msg_geometry_msgs_msg_twist/0 is not implemented")
 
   def init_msg_geometry_msgs_msg_twist(_),
-    do: raise("NIF init_msg_geometry_msgs_msg_twist/1 is not implemented")
+    do: :erlang.nif_error("NIF init_msg_geometry_msgs_msg_twist/1 is not implemented")
 
   def setdata_geometry_msgs_msg_twist(_, _),
-    do: raise("NIF setdata_geometry_msgs_msg_twist/2 is not implemented")
+    do: :erlang.nif_error("NIF setdata_geometry_msgs_msg_twist/2 is not implemented")
 
   def readdata_geometry_msgs_msg_twist(_),
-    do: raise("NIF readdata_geometry_msgs_msg_twist/1 is not implemented")
+    do: :erlang.nif_error("NIF readdata_geometry_msgs_msg_twist/1 is not implemented")
 
   def get_typesupport_std_msgs_msg_string,
-    do: raise("NIF get_typesupport_std_msgs_msg_string/0 is not implemented")
+    do: :erlang.nif_error("NIF get_typesupport_std_msgs_msg_string/0 is not implemented")
 
   def create_empty_msg_std_msgs_msg_string,
-    do: raise("NIF create_empty_msg_std_msgs_msg_string/0 is not implemented")
+    do: :erlang.nif_error("NIF create_empty_msg_std_msgs_msg_string/0 is not implemented")
 
   def init_msg_std_msgs_msg_string(_),
-    do: raise("NIF init_msg_std_msgs_msg_string/1 is not implemented")
+    do: :erlang.nif_error("NIF init_msg_std_msgs_msg_string/1 is not implemented")
 
   def setdata_std_msgs_msg_string(_, _),
-    do: raise("NIF setdata_std_msgs_msg_string/2 is not implemented")
+    do: :erlang.nif_error("NIF setdata_std_msgs_msg_string/2 is not implemented")
 
   def readdata_std_msgs_msg_string(_),
-    do: raise("NIF readdata_std_msgs_msg_string/1 is not implemented")
+    do: :erlang.nif_error("NIF readdata_std_msgs_msg_string/1 is not implemented")
 
   # -----<custom_msgtype>_nif.c-----end-----
 end

--- a/lib/rclex/node.ex
+++ b/lib/rclex/node.ex
@@ -88,7 +88,7 @@ defmodule Rclex.Node do
     {:ok, {node, node_name, supervisor_ids}}
   end
 
-  def create_single_subscriber(node_identifier, msg_type, topic_name) do
+  def create_subscriber(node_identifier, msg_type, topic_name) do
     GenServer.call(
       {:global, node_identifier},
       {:create_subscriber, node_identifier, msg_type, topic_name}
@@ -129,7 +129,7 @@ defmodule Rclex.Node do
     {:ok, sub_identifier_list}
   end
 
-  def create_single_publisher(node_identifier, msg_type, topic_name) do
+  def create_publisher(node_identifier, msg_type, topic_name) do
     GenServer.call(
       {:global, node_identifier},
       {:create_publisher, node_identifier, msg_type, topic_name}

--- a/lib/rclex/node.ex
+++ b/lib/rclex/node.ex
@@ -197,20 +197,6 @@ defmodule Rclex.Node do
     {:reply, :ok, {node, name, new_supervisor_ids}}
   end
 
-  # def handle_call({:finish_subscriber, topic_name}, _from, {node, node_name, supervisor_ids}) do
-  #   {:ok, supervisor_id} = Map.fetch(supervisor_ids, {:sub, topic_name})
-
-  #   sub_key = "#{node_name}/sub/#{topic_name}"
-
-  #   :ok = GenServer.call({:global, sub_key}, {:finish_subscriber, node})
-
-  #   Supervisor.stop(supervisor_id)
-
-  #   new_supervisor_ids = Map.delete(supervisor_ids, topic_name)
-
-  #   {:reply, :ok, {node, node_name, new_supervisor_ids}}
-  # end
-
   def handle_call(:finish_node, _from, {node, name, supervisor_ids}) do
     Nifs.rcl_node_fini(node)
 

--- a/lib/rclex/node.ex
+++ b/lib/rclex/node.ex
@@ -1,6 +1,5 @@
 defmodule Rclex.Node do
   alias Rclex.Nifs
-  require Rclex.Macros
   require Logger
   use GenServer, restart: :transient
 

--- a/lib/rclex/node.ex
+++ b/lib/rclex/node.ex
@@ -13,6 +13,7 @@ defmodule Rclex.Node do
     )
   end
 
+  @impl GenServer
   def init({node, node_identifier, queue_length, change_order}) do
     children = [
       {Rclex.JobQueue, {node_identifier, queue_length}},
@@ -136,6 +137,7 @@ defmodule Rclex.Node do
     )
   end
 
+  @impl GenServer
   def handle_call(
         {:create_subscriber, node_identifier, msg_type, topic_name},
         _,
@@ -157,6 +159,7 @@ defmodule Rclex.Node do
     {:reply, {:ok, {node_identifier, topic_name, :sub}}, {node, name, new_supervisor_ids}}
   end
 
+  @impl GenServer
   def handle_call(
         {:create_publisher, node_identifier, msg_type, topic_name},
         _,
@@ -180,6 +183,7 @@ defmodule Rclex.Node do
 
   # Publisher、Subscriberを終了する
   # roleには"pub"、"sub"のどちらかを指定する
+  @impl GenServer
   def handle_call({:finish_job, topic_name, role}, _from, {node, name, supervisor_ids}) do
     {:ok, supervisor_id} = Map.fetch(supervisor_ids, {role, topic_name})
 
@@ -196,6 +200,7 @@ defmodule Rclex.Node do
     {:reply, :ok, {node, name, new_supervisor_ids}}
   end
 
+  @impl GenServer
   def handle_call(:finish_node, _from, {node, name, supervisor_ids}) do
     Nifs.rcl_node_fini(node)
 
@@ -208,12 +213,14 @@ defmodule Rclex.Node do
     {:reply, :ok, {node, name, new_supervisor_ids}}
   end
 
+  @impl GenServer
   def handle_call(:node_get_name, _from, state) do
     {node, _, _} = state
     node_name = Nifs.rcl_node_get_name(node)
     {:reply, node_name, state}
   end
 
+  @impl GenServer
   def handle_call({:get_topic_names_and_types, allocator, no_demangle}, _from, state) do
     {node, _, _} = state
     names_and_types_list = Nifs.rcl_get_topic_names_and_types(node, allocator, no_demangle)

--- a/lib/rclex/node.ex
+++ b/lib/rclex/node.ex
@@ -8,48 +8,16 @@ defmodule Rclex.Node do
     T.B.A
   """
 
-  def start_link({node, node_name}) do
-    GenServer.start_link(__MODULE__, {node, node_name}, name: {:global, node_name})
-  end
-
-  def start_link({node, node_name, :executor_setting, {queue_length}}) do
-    GenServer.start_link(__MODULE__, {node, node_name, queue_length}, name: {:global, node_name})
-  end
-
-  def start_link({node, node_name, :executor_setting, {queue_length, change_order}}) do
-    GenServer.start_link(__MODULE__, {node, node_name, queue_length, change_order},
-      name: {:global, node_name}
-    )
-  end
-
-  def start_link({node, node_name, node_namespace}) do
-    node_identifier = "#{node_namespace}/#{node_name}"
-
-    GenServer.start_link(__MODULE__, {node, node_identifier}, name: {:global, node_identifier})
-  end
-
-  def start_link({node, node_name, node_namespace, :executor_setting, {queue_length}}) do
-    node_identifier = "#{node_namespace}/#{node_name}"
-
-    GenServer.start_link(__MODULE__, {node, node_identifier, queue_length},
-      name: {:global, node_identifier}
-    )
-  end
-
-  def start_link(
-        {node, node_name, node_namespace, :executor_setting, {queue_length, change_order}}
-      ) do
-    node_identifier = "#{node_namespace}/#{node_name}"
-
+  def start_link({node, node_identifier, {queue_length, change_order}}) do
     GenServer.start_link(__MODULE__, {node, node_identifier, queue_length, change_order},
       name: {:global, node_identifier}
     )
   end
 
-  def init({node, node_name}) do
+  def init({node, node_identifier, queue_length, change_order}) do
     children = [
-      {Rclex.JobQueue, {node_name}},
-      {Rclex.JobExecutor, {node_name}}
+      {Rclex.JobQueue, {node_identifier, queue_length}},
+      {Rclex.JobExecutor, {node_identifier, change_order}}
     ]
 
     opts = [strategy: :one_for_one]
@@ -57,35 +25,7 @@ defmodule Rclex.Node do
     # supervisor_idsにはJob、Publisher、Subscriberのsupervisor_idを入れる
     # Publisher、Subscriberは第2クエリとしてトピック名を指定する
     supervisor_ids = Map.put_new(%{}, {:job, "supervisor"}, id)
-    {:ok, {node, node_name, supervisor_ids}}
-  end
-
-  def init({node, node_name, queue_length}) do
-    children = [
-      {Rclex.JobQueue, {node_name, queue_length}},
-      {Rclex.JobExecutor, {node_name}}
-    ]
-
-    opts = [strategy: :one_for_one]
-    {:ok, id} = Supervisor.start_link(children, opts)
-    # supervisor_idsにはJob、Publisher、Subscriberのsupervisor_idを入れる
-    # Publisher、Subscriberは第2クエリとしてトピック名を指定する
-    supervisor_ids = Map.put_new(%{}, {:job, "supervisor"}, id)
-    {:ok, {node, node_name, supervisor_ids}}
-  end
-
-  def init({node, node_name, queue_length, change_order}) do
-    children = [
-      {Rclex.JobQueue, {node_name, queue_length}},
-      {Rclex.JobExecutor, {node_name, change_order}}
-    ]
-
-    opts = [strategy: :one_for_one]
-    {:ok, id} = Supervisor.start_link(children, opts)
-    # supervisor_idsにはJob、Publisher、Subscriberのsupervisor_idを入れる
-    # Publisher、Subscriberは第2クエリとしてトピック名を指定する
-    supervisor_ids = Map.put_new(%{}, {:job, "supervisor"}, id)
-    {:ok, {node, node_name, supervisor_ids}}
+    {:ok, {node, node_identifier, supervisor_ids}}
   end
 
   def create_subscriber(node_identifier, msg_type, topic_name) do

--- a/lib/rclex/publisher.ex
+++ b/lib/rclex/publisher.ex
@@ -15,6 +15,7 @@ defmodule Rclex.Publisher do
     GenServer.start_link(__MODULE__, pub, name: {:global, process_name})
   end
 
+  @impl GenServer
   @doc """
     publisherプロセスの初期化
   """
@@ -56,16 +57,19 @@ defmodule Rclex.Publisher do
     :ok
   end
 
+  @impl GenServer
   def handle_cast({:publish, msg}, pub) do
     Rclex.Publisher.publish_once(pub, msg, Nifs.create_pub_alloc())
     {:noreply, pub}
   end
 
+  @impl GenServer
   def handle_call({:finish, node}, _from, pub) do
     Nifs.rcl_publisher_fini(pub, node)
     {:reply, {:ok, 'publisher finished: '}, pub}
   end
 
+  @impl GenServer
   def terminate(:normal, _) do
     Logger.debug("terminate publisher")
   end

--- a/lib/rclex/publisher.ex
+++ b/lib/rclex/publisher.ex
@@ -1,6 +1,6 @@
 defmodule Rclex.Publisher do
   alias Rclex.Nifs
-  require Rclex.Macros
+  require Rclex.ReturnCode
   require Logger
   use GenServer
 
@@ -24,16 +24,16 @@ defmodule Rclex.Publisher do
 
   def publish_once(pub, pubmsg, pub_alloc) do
     case Nifs.rcl_publish(pub, pubmsg, pub_alloc) do
-      {Rclex.Macros.rcl_ret_ok(), _, _} ->
+      {Rclex.ReturnCode.rcl_ret_ok(), _, _} ->
         Logger.debug("publish ok")
 
-      {Rclex.Macros.rcl_ret_publisher_invalid(), _, _} ->
+      {Rclex.ReturnCode.rcl_ret_publisher_invalid(), _, _} ->
         Logger.error("Publisher is invalid")
 
-      {Rclex.Macros.rmw_ret_invalid_argument(), _, _} ->
+      {Rclex.ReturnCode.rmw_ret_invalid_argument(), _, _} ->
         Logger.error("invalid argument is contained")
 
-      {Rclex.Macros.rcl_ret_error(), _, _} ->
+      {Rclex.ReturnCode.rcl_ret_error(), _, _} ->
         Logger.error("unspecified error")
 
       {_, _, _} ->

--- a/lib/rclex/resource_server.ex
+++ b/lib/rclex/resource_server.ex
@@ -68,10 +68,10 @@ defmodule Rclex.ResourceServer do
   """
   @spec create_nodes(context(), charlist(), integer(), integer(), (list() -> list())) :: term()
   def create_nodes(context, node_name, num_node, queue_length \\ 1, change_order \\ & &1) do
-    create_nodes_with_ns(context, node_name, '', num_node, queue_length, change_order)
+    create_nodes_with_namespace(context, node_name, '', num_node, queue_length, change_order)
   end
 
-  @spec create_nodes_with_ns(
+  @spec create_nodes_with_namespace(
           context(),
           charlist(),
           charlist(),
@@ -79,7 +79,7 @@ defmodule Rclex.ResourceServer do
           integer(),
           (list() -> list())
         ) :: term()
-  def create_nodes_with_ns(
+  def create_nodes_with_namespace(
         context,
         node_name,
         node_namespace,

--- a/lib/rclex/resource_server.ex
+++ b/lib/rclex/resource_server.ex
@@ -1,6 +1,5 @@
 defmodule Rclex.ResourceServer do
   alias Rclex.Nifs
-  require Rclex.Macros
   require Logger
   use GenServer, restart: :transient
 

--- a/lib/rclex/resource_server.ex
+++ b/lib/rclex/resource_server.ex
@@ -29,12 +29,12 @@ defmodule Rclex.ResourceServer do
           node_identifier :: string()
           作成したノードプロセスのnameを返す
   """
-  def create_singlenode(context, node_name, node_namespace) do
-    GenServer.call(ResourceServer, {:create_singlenode, {context, node_name, node_namespace}})
+  def create_node(context, node_name, node_namespace) do
+    GenServer.call(ResourceServer, {:create_node, {context, node_name, node_namespace}})
   end
 
-  def create_singlenode(context, node_name) do
-    GenServer.call(ResourceServer, {:create_singlenode, {context, node_name}})
+  def create_node(context, node_name) do
+    GenServer.call(ResourceServer, {:create_node, {context, node_name}})
   end
 
   @doc """
@@ -45,30 +45,30 @@ defmodule Rclex.ResourceServer do
           作成したノードプロセスのnameを返す
   """
 
-  def create_singlenode_with_executor_setting(context, node_name, {queue_length}) do
+  def create_node_with_executor_setting(context, node_name, {queue_length}) do
     GenServer.call(
       ResourceServer,
-      {:create_singlenode_with_executor_setting, {context, node_name, {queue_length}}}
+      {:create_node_with_executor_setting, {context, node_name, {queue_length}}}
     )
   end
 
-  def create_singlenode_with_executor_setting(context, node_name, {queue_length, change_order}) do
+  def create_node_with_executor_setting(context, node_name, {queue_length, change_order}) do
     GenServer.call(
       ResourceServer,
-      {:create_singlenode_with_executor_setting,
+      {:create_node_with_executor_setting,
        {context, node_name, {queue_length, change_order}}}
     )
   end
 
-  def create_singlenode_with_executor_setting(context, node_name, node_name_space, {queue_length}) do
+  def create_node_with_executor_setting(context, node_name, node_name_space, {queue_length}) do
     GenServer.call(
       ResourceServer,
-      {:create_singlenode_with_executor_setting,
+      {:create_node_with_executor_setting,
        {context, node_name, node_name_space, {queue_length}}}
     )
   end
 
-  def create_singlenode_with_executor_setting(
+  def create_node_with_executor_setting(
         context,
         node_name,
         node_name_space,
@@ -76,7 +76,7 @@ defmodule Rclex.ResourceServer do
       ) do
     GenServer.call(
       ResourceServer,
-      {:create_singlenode_with_executor_setting,
+      {:create_node_with_executor_setting,
        {context, node_name, node_name_space, {queue_length, change_order}}}
     )
   end
@@ -224,7 +224,7 @@ defmodule Rclex.ResourceServer do
     )
   end
 
-  def handle_call({:create_singlenode, {context, node_name, node_namespace}}, _from, {resources}) do
+  def handle_call({:create_node, {context, node_name, node_namespace}}, _from, {resources}) do
     if Map.has_key?(resources, {node_namespace, node_name}) do
       # 同名のノードがすでに存在しているときはエラーを返す
       {:reply, {:error, node_name}}
@@ -245,7 +245,7 @@ defmodule Rclex.ResourceServer do
     end
   end
 
-  def handle_call({:create_singlenode, {context, node_name}}, _from, {resources}) do
+  def handle_call({:create_node, {context, node_name}}, _from, {resources}) do
     if Map.has_key?(resources, {"", node_name}) do
       # 同名のノードがすでに存在しているときはエラーを返す
       {:reply, {:error, node_name}}
@@ -266,7 +266,7 @@ defmodule Rclex.ResourceServer do
   end
 
   def handle_call(
-        {:create_singlenode_with_executor_setting,
+        {:create_node_with_executor_setting,
          {context, node_name, node_namespace, executor_settings}},
         _from,
         {resources}
@@ -292,7 +292,7 @@ defmodule Rclex.ResourceServer do
   end
 
   def handle_call(
-        {:create_singlenode_with_executor_setting, {context, node_name, executor_settings}},
+        {:create_node_with_executor_setting, {context, node_name, executor_settings}},
         _from,
         {resources}
       ) do

--- a/lib/rclex/return_code.ex
+++ b/lib/rclex/return_code.ex
@@ -1,8 +1,7 @@
-defmodule Rclex.Macros do
+defmodule Rclex.ReturnCode do
   @moduledoc """
   T.B.A
   """
-
   defmacro rcl_ret_ok, do: 0
   defmacro rcl_ret_error, do: 1
   defmacro rcl_ret_timeout, do: 2

--- a/lib/rclex/sub_loop.ex
+++ b/lib/rclex/sub_loop.ex
@@ -1,6 +1,6 @@
 defmodule Rclex.SubLoop do
   alias Rclex.Nifs
-  require Rclex.Macros
+  require Rclex.ReturnCode
   require Logger
   use GenServer, restart: :transient
 
@@ -52,16 +52,16 @@ defmodule Rclex.SubLoop do
       sub_key = {:global, "#{node_identifier}/#{topic_name}/sub"}
 
       case Nifs.rcl_take(sub, msg, msginfo, sub_alloc) do
-        {Rclex.Macros.rcl_ret_ok(), _, _, _} ->
+        {Rclex.ReturnCode.rcl_ret_ok(), _, _, _} ->
           GenServer.cast(
             {:global, "#{node_identifier}/JobQueue"},
             {:push, {sub_key, :subscribe, msg}}
           )
 
-        {Rclex.Macros.rcl_ret_subscription_invalid(), _, _, _} ->
+        {Rclex.ReturnCode.rcl_ret_subscription_invalid(), _, _, _} ->
           Logger.error("subscription invalid")
 
-        {Rclex.Macros.rcl_ret_subscription_take_failed(), _, _, _} ->
+        {Rclex.ReturnCode.rcl_ret_subscription_take_failed(), _, _, _} ->
           do_nothing()
       end
     end

--- a/lib/rclex/sub_loop.ex
+++ b/lib/rclex/sub_loop.ex
@@ -15,6 +15,7 @@ defmodule Rclex.SubLoop do
     )
   end
 
+  @impl GenServer
   def init({node_identifier, msg_type, topic_name, sub, context, call_back}) do
     wait_set =
       Nifs.rcl_get_zero_initialized_wait_set()
@@ -42,7 +43,6 @@ defmodule Rclex.SubLoop do
       購読処理関数
       購読が正常に行われれば，引数に受け取っていたコールバック関数を実行
   """
-  # def each_subscribe(sub, call_back, sub_id) do
   def each_subscribe(sub, node_identifier, msg_type, topic_name) do
     # Logger.debug("each subscribe")
     if Nifs.check_subscription(sub) do
@@ -67,11 +67,13 @@ defmodule Rclex.SubLoop do
     end
   end
 
+  @impl GenServer
   def handle_cast({:loop}, {node_identifier, msg_type, topic_name, wait_set, sub, call_back}) do
     {:noreply, {node_identifier, msg_type, topic_name, wait_set, sub, call_back},
      {:continue, :loop}}
   end
 
+  @impl GenServer
   def handle_continue(:loop, {node_identifier, msg_type, topic_name, wait_set, sub, call_back}) do
     Nifs.rcl_wait_set_clear(wait_set)
     # waitsetにサブスクライバを追加する
@@ -98,12 +100,12 @@ defmodule Rclex.SubLoop do
     end
   end
 
-  # def terminate(:normal, state) do
+  @impl GenServer
   def terminate(:normal, _) do
     Logger.debug("sub_loop process killed : normal")
   end
 
-  # def terminate(:shutdown, state) do
+  @impl GenServer
   def terminate(:shutdown, _) do
     Logger.debug("sub_loop process killed : shutdown")
   end

--- a/lib/rclex/subscriber.ex
+++ b/lib/rclex/subscriber.ex
@@ -1,6 +1,5 @@
 defmodule Rclex.Subscriber do
   alias Rclex.Nifs
-  require Rclex.Macros
   require Logger
   use GenServer
 

--- a/lib/rclex/subscriber.ex
+++ b/lib/rclex/subscriber.ex
@@ -15,6 +15,7 @@ defmodule Rclex.Subscriber do
     GenServer.start_link(__MODULE__, {sub, msg_type}, name: {:global, process_name})
   end
 
+  @impl GenServer
   @doc """
     subscriberプロセスの初期化
     subscriberを状態として持つ。start_subscribingをした際にcontextとcall_backを追加で状態として持つ。
@@ -55,6 +56,7 @@ defmodule Rclex.Subscriber do
     end)
   end
 
+  @impl GenServer
   def handle_cast({:start_subscribing, {context, call_back, node_identifier, topic_name}}, state) do
     {:ok, sub} = Map.fetch(state, :subscriber)
     {:ok, msg_type} = Map.fetch(state, :msgtype)
@@ -76,6 +78,7 @@ defmodule Rclex.Subscriber do
      }}
   end
 
+  @impl GenServer
   @doc """
     コールバックの実行
   """
@@ -85,10 +88,12 @@ defmodule Rclex.Subscriber do
     {:noreply, state}
   end
 
+  @impl GenServer
   def handle_cast(:stop, state) do
     {:stop, :normal, state}
   end
 
+  @impl GenServer
   def handle_call(:stop_subscribing, _from, state) do
     {:ok, supervisor_id} = Map.fetch(state, :supervisor_id)
     Supervisor.stop(supervisor_id)
@@ -96,18 +101,21 @@ defmodule Rclex.Subscriber do
     {:reply, :ok, new_state}
   end
 
+  @impl GenServer
   def handle_call({:finish, node}, _from, state) do
     {:ok, sub} = Map.fetch(state, :subscriber)
     Nifs.rcl_subscription_fini(sub, node)
     {:reply, {:ok, 'subscriber finished: '}, state}
   end
 
+  @impl GenServer
   def handle_call({:finish_subscriber, node}, _from, state) do
     {:ok, sub} = Map.fetch(state, :subscriber)
     Nifs.rcl_subscription_fini(sub, node)
     {:reply, :ok, state}
   end
 
+  @impl GenServer
   def terminate(:normal, _) do
     Logger.debug("terminate subscriber")
   end

--- a/lib/rclex/timer.ex
+++ b/lib/rclex/timer.ex
@@ -21,6 +21,7 @@ defmodule Rclex.Timer do
   # limit: 最大実行回数
   # queue_length: エグゼキュータのキューの長さ
   # change_order: ジョブの実行順序を変更する関数
+  @impl GenServer
   def init({callback, args, time, timer_name, limit, {queue_length, change_order}}) do
     job_children = [
       {Rclex.JobQueue, {timer_name, queue_length}},
@@ -39,23 +40,27 @@ defmodule Rclex.Timer do
     {:ok, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
   end
 
+  @impl GenServer
   def handle_cast({:execute, _}, {callback, args, time, loop_supervisor_id, job_supervisor_id}) do
     callback.(args)
     {:noreply, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
   end
 
+  @impl GenServer
   def handle_cast({:stop, _}, {callback, args, time, loop_supervisor_id, job_supervisor_id}) do
     Logger.info("the number of timer loop reaches limit")
     Supervisor.stop(loop_supervisor_id)
     {:stop, :normal, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
   end
 
+  @impl GenServer
   def handle_call(:stop, _from, {callback, args, time, loop_supervisor_id, job_supervisor_id}) do
     Logger.debug("stop timer")
     Supervisor.stop(loop_supervisor_id)
     {:reply, :ok, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
   end
 
+  @impl GenServer
   def terminate(:normal, _) do
     Logger.debug("terminate timer")
   end

--- a/lib/rclex/timer.ex
+++ b/lib/rclex/timer.ex
@@ -7,30 +7,10 @@ defmodule Rclex.Timer do
     T.B.A
   """
 
-  def start_link({callback, args, time, timer_name}) do
-    GenServer.start_link(__MODULE__, {callback, args, time, timer_name},
-      name: {:global, "#{timer_name}/Timer"}
-    )
-  end
-
-  def start_link({callback, args, time, timer_name, limit}) do
-    GenServer.start_link(__MODULE__, {callback, args, time, timer_name, limit},
-      name: {:global, "#{timer_name}/Timer"}
-    )
-  end
-
-  def start_link({callback, args, time, timer_name, :executor_setting, executor_settings}) do
+  def start_link({callback, args, time, timer_name, limit, executor_settings}) do
     GenServer.start_link(
       __MODULE__,
-      {callback, args, time, timer_name, :executor_setting, executor_settings},
-      name: {:global, "#{timer_name}/Timer"}
-    )
-  end
-
-  def start_link({callback, args, time, timer_name, limit, :executor_setting, executor_settings}) do
-    GenServer.start_link(
-      __MODULE__,
-      {callback, args, time, timer_name, limit, :executor_setting, executor_settings},
+      {callback, args, time, timer_name, limit, executor_settings},
       name: {:global, "#{timer_name}/Timer"}
     )
   end
@@ -42,101 +22,7 @@ defmodule Rclex.Timer do
   # limit: 最大実行回数
   # queue_length: エグゼキュータのキューの長さ
   # change_order: ジョブの実行順序を変更する関数
-  def init({callback, args, time, timer_name}) do
-    job_children = [
-      {Rclex.JobQueue, {timer_name}},
-      {Rclex.JobExecutor, {timer_name}}
-    ]
-
-    opts = [strategy: :one_for_one]
-    {:ok, job_supervisor_id} = Supervisor.start_link(job_children, opts)
-
-    children = [
-      {Rclex.TimerLoop, {timer_name, time}}
-    ]
-
-    opts = [strategy: :one_for_one]
-    {:ok, loop_supervisor_id} = Supervisor.start_link(children, opts)
-    {:ok, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
-  end
-
-  def init({callback, args, time, timer_name, limit}) do
-    job_children = [
-      {Rclex.JobQueue, {timer_name}},
-      {Rclex.JobExecutor, {timer_name}}
-    ]
-
-    opts = [strategy: :one_for_one]
-    {:ok, job_supervisor_id} = Supervisor.start_link(job_children, opts)
-
-    children = [
-      {Rclex.TimerLoop, {timer_name, time, limit}}
-    ]
-
-    opts = [strategy: :one_for_one]
-    {:ok, loop_supervisor_id} = Supervisor.start_link(children, opts)
-    {:ok, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
-  end
-
-  def init({callback, args, time, timer_name, :executor_setting, {queue_length}}) do
-    job_children = [
-      {Rclex.JobQueue, {timer_name, queue_length}},
-      {Rclex.JobExecutor, {timer_name}}
-    ]
-
-    opts = [strategy: :one_for_one]
-    {:ok, job_supervisor_id} = Supervisor.start_link(job_children, opts)
-
-    children = [
-      {Rclex.TimerLoop, {timer_name, time}}
-    ]
-
-    opts = [strategy: :one_for_one]
-    {:ok, loop_supervisor_id} = Supervisor.start_link(children, opts)
-    {:ok, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
-  end
-
-  def init({callback, args, time, timer_name, :executor_setting, {queue_length, change_order}}) do
-    job_children = [
-      {Rclex.JobQueue, {timer_name, queue_length}},
-      {Rclex.JobExecutor, {timer_name, change_order}}
-    ]
-
-    Logger.debug(change_order.("timer"))
-
-    opts = [strategy: :one_for_one]
-    {:ok, job_supervisor_id} = Supervisor.start_link(job_children, opts)
-
-    children = [
-      {Rclex.TimerLoop, {timer_name, time}}
-    ]
-
-    opts = [strategy: :one_for_one]
-    {:ok, loop_supervisor_id} = Supervisor.start_link(children, opts)
-    {:ok, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
-  end
-
-  def init({callback, args, time, timer_name, limit, :executor_setting, {queue_length}}) do
-    job_children = [
-      {Rclex.JobQueue, {timer_name, queue_length}},
-      {Rclex.JobExecutor, {timer_name}}
-    ]
-
-    opts = [strategy: :one_for_one]
-    {:ok, job_supervisor_id} = Supervisor.start_link(job_children, opts)
-
-    children = [
-      {Rclex.TimerLoop, {timer_name, time, limit}}
-    ]
-
-    opts = [strategy: :one_for_one]
-    {:ok, loop_supervisor_id} = Supervisor.start_link(children, opts)
-    {:ok, {callback, args, time, loop_supervisor_id, job_supervisor_id}}
-  end
-
-  def init(
-        {callback, args, time, timer_name, limit, :executor_setting, {queue_length, change_order}}
-      ) do
+  def init({callback, args, time, timer_name, limit, {queue_length, change_order}}) do
     job_children = [
       {Rclex.JobQueue, {timer_name, queue_length}},
       {Rclex.JobExecutor, {timer_name, change_order}}

--- a/lib/rclex/timer.ex
+++ b/lib/rclex/timer.ex
@@ -1,5 +1,4 @@
 defmodule Rclex.Timer do
-  require Rclex.Macros
   require Logger
   use GenServer, restart: :transient
 

--- a/lib/rclex/timer_loop.ex
+++ b/lib/rclex/timer_loop.ex
@@ -10,15 +10,18 @@ defmodule Rclex.TimerLoop do
     GenServer.start_link(__MODULE__, {timer_name, time, limit})
   end
 
+  @impl GenServer
   def init({timer_name, time, limit}) do
     GenServer.cast(self(), :loop)
     {:ok, {timer_name, time, 0, limit}}
   end
 
+  @impl GenServer
   def handle_cast(:loop, state) do
     {:noreply, state, {:continue, :loop}}
   end
 
+  @impl GenServer
   def handle_continue(:loop, {timer_name, time, count, limit}) do
     timer_id = {:global, "#{timer_name}/Timer"}
     count = count + 1
@@ -40,10 +43,12 @@ defmodule Rclex.TimerLoop do
     end
   end
 
+  @impl GenServer
   def terminate(:normal, _) do
     Logger.debug("timer_loop process killed : normal")
   end
 
+  @impl GenServer
   def terminate(:shutdown, _) do
     Logger.debug("timer_loop process killed : shutdown")
   end

--- a/lib/rclex/timer_loop.ex
+++ b/lib/rclex/timer_loop.ex
@@ -1,5 +1,4 @@
 defmodule Rclex.TimerLoop do
-  require Rclex.Macros
   require Logger
   use GenServer, restart: :transient
 

--- a/test/rclex_test.exs
+++ b/test/rclex_test.exs
@@ -21,10 +21,9 @@ defmodule RclexTest do
     context = Rclex.rclexinit()
     str_data = "data"
 
-    {:ok, sub_node} = Rclex.ResourceServer.create_singlenode(context, 'listener')
+    {:ok, sub_node} = Rclex.ResourceServer.create_node(context, 'listener')
 
-    {:ok, subscriber} =
-      Rclex.Node.create_single_subscriber(sub_node, 'StdMsgs.Msg.String', 'chatter')
+    {:ok, subscriber} = Rclex.Node.create_subscriber(sub_node, 'StdMsgs.Msg.String', 'chatter')
 
     Rclex.Subscriber.start_subscribing([subscriber], context, fn msg ->
       recv_msg = Rclex.Msg.read(msg, 'StdMsgs.Msg.String')
@@ -33,10 +32,9 @@ defmodule RclexTest do
       IO.puts("Rclex: received msg: #{msg_data}")
     end)
 
-    {:ok, pub_node} = Rclex.ResourceServer.create_singlenode(context, 'talker')
+    {:ok, pub_node} = Rclex.ResourceServer.create_node(context, 'talker')
 
-    {:ok, publisher} =
-      Rclex.Node.create_single_publisher(pub_node, 'StdMsgs.Msg.String', 'chatter')
+    {:ok, publisher} = Rclex.Node.create_publisher(pub_node, 'StdMsgs.Msg.String', 'chatter')
 
     {:ok, timer} =
       Rclex.ResourceServer.create_timer(

--- a/test/rclex_test.exs
+++ b/test/rclex_test.exs
@@ -37,7 +37,7 @@ defmodule RclexTest do
     {:ok, publisher} = Rclex.Node.create_publisher(pub_node, 'StdMsgs.Msg.String', 'chatter')
 
     {:ok, timer} =
-      Rclex.ResourceServer.create_timer(
+      Rclex.ResourceServer.create_timer_with_limit(
         fn publisher ->
           msg = Rclex.Msg.initialize('StdMsgs.Msg.String')
 

--- a/test/rclex_test.exs
+++ b/test/rclex_test.exs
@@ -20,6 +20,7 @@ defmodule RclexTest do
   test "single_pub_sub" do
     context = Rclex.rclexinit()
     str_data = "data"
+    pid = self()
 
     {:ok, sub_node} = Rclex.ResourceServer.create_node(context, 'listener')
 
@@ -29,7 +30,7 @@ defmodule RclexTest do
       recv_msg = Rclex.Msg.read(msg, 'StdMsgs.Msg.String')
       assert List.to_string(recv_msg.data) == str_data, "received data is correct."
       msg_data = List.to_string(recv_msg.data)
-      IO.puts("Rclex: received msg: #{msg_data}")
+      send(pid, :message_received)
     end)
 
     {:ok, pub_node} = Rclex.ResourceServer.create_node(context, 'talker')
@@ -55,7 +56,7 @@ defmodule RclexTest do
         1
       )
 
-    Process.sleep(500)
+    assert_receive :message_received, 500
 
     Rclex.ResourceServer.stop_timer(timer)
     Rclex.Subscriber.stop_subscribing([subscriber])


### PR DESCRIPTION

# Refactoring lists

 - rename and simplify functions
 - delete comment out functions
 - change NIF exception handling
 - add @spac and @impl
 - refine tests
 
# Changes
## modules
| previous   | changed   |
| ---------   | ----------   |
| Rclex.Macros | Rclex.ReturnCode |

## functions
### ResourceServer module

| previous   | changed   |
| ----------- | ---------- |
| create_singlenode(context, node_name) | create_node(context, node_name, queue_length \\ 1, change_order \\ & &1) |
| create_singlenode_with_executor_setting(context, node_name, {queue_length}) | [deprecated] executor_settings changes to default value.↑ |
| create_singlenode_with_executor_setting(context, node_name, {queue_length, change_order}) | [deprecated] executor_settings changes to default value.↑ |
| create_singlenode(context, node_name, node_namespace) | create_node_with_namespace(context, node_name, node_namespace, queue_length \\ 1, change_order \\ & &1) |
| create_singlenode_with_executor_setting(context, node_name, node_name_space, {queue_length}) | [deprecated] executor_settings changes to default value.↑ |
| create_singlenode_with_executor_setting(context, node_name, node_name_space, {queue_length, change_order}) | [deprecated] executor_settings changes to default value.↑ |
| create_nodes(context, node_name, num_node) | create_nodes(context, node_name, num_node, queue_length \\ 1, change_order \\ & &1) | create_nodes(context, node_name, num_node, queue_length \\ 1, change_order \\ & &1) |
| create_nodes_with_executor_setting(context, node_name, num_node, {queue_length}) | [deprecated] executor_settings changes to default value.↑ |
| create_nodes_with_executor_setting(context, node_name, num_node, {queue_length, change_order}) | [deprecated] executor_settings changes to default value.↑ |
| create_nodes(context, node_name, namespace, num_node) | create_nodes_with_namespace(context, node_name, node_namespace, num_node, queue_length \\ 1, change_order \\ & &1) |
| create_nodes_with_executor_setting(context, node_name, node_name_space, num_node, {queue_length}) | [deprecated] executor_settings changes to default value.↑ |
| create_nodes_with_executor_setting(context, node_name, node_name_space, num_node, {queue_length, change_order}) | [deprecated] executor_settings changes to default value.↑ |
| create_timer(call_back, args, time, timer_name) | create_timer(call_back, args, time, timer_name, queue_length \\ 1, change_order \\ & &1) |
| create_timer_with_executor_setting(call_back, args, time, timer_name, {queue_length}) | [deprecated] executor_settings changes to default value.↑ |
| create_timer_with_executor_setting(call_back, args, time, timer_name, {queue_length, change_order}) | [deprecated] executor_settings changes to default value.↑ |
| create_timer(call_back, args, time, timer_name, limit) | create_timer_with_limit(call_back, args, time, timer_name, limit, queue_length \\ 1, change_order \\ & &1) |
| create_timer_with_executor_setting(call_back, args, time, timer_name, limit, {queue_length}) | [deprecated] executor_settings changes to default value.↑ |
| create_timer_with_executor_setting(call_back, args, time, timer_name, limit, {queue_length, change_order}) | [deprecated] executor_settings changes to default value.↑ |
| handle_call({:create_singlenode, {context, node_name, node_namespace}}, _from, {resources}) | handle_call({:create_nodes, {context, node_name, namespace, num_node, executor_settings}}, _from, {resources}) | 
| handle_call({:create_singlenode, {context, node_name}}, _from, {resources}) | [deprecated] aggregate to ↑ |
| handle_call({:create_singlenode_with_executor_setting, {context, node_name, node_namespace, executor_settings}}, _from, {resources}) | [deprecated] aggregate to ↑ |
| handle_call({:create_singlenode_with_executor_setting, {context, node_name, executor_settings}}, _from, {resources}) | [deprecated] aggregate to ↑ |
| handle_call({:create_nodes, {context, node_name, namespace, num_node}}, _from, {resources}) | [deprecated] aggregate to ↑ |
| handle_call({:create_nodes, {context, node_name, num_node}}, _from, {resources}) | [deprecated] aggregate to ↑ |
| handle_call({:create_nodes_with_executor_setting, {context, node_name, namespace, num_node, executor_settings}}, _from, {resources}) | [deprecated] aggregate to ↑ |
| handle_call({:create_nodes_with_executor_setting, {context, node_name, num_node, executor_settings}}, _from, {resources}) | [deprecated] aggregate to ↑ |
| handle_call({:create_timer, {call_back, args, time, timer_name}}, _from, {resources}) | handle_call({:create_timer, {call_back, args, time, timer_name, limit, executor_settings}}, _from, {resources}) |
| handle_call({:create_timer, {call_back, args, time, timer_name, limit}}, _from, {resources}) | [deprecated] aggregate to ↑ |
| handle_call({:create_timer_with_executor_setting, {call_back, args, time, timer_name, executor_settings}}, _from, {resources}) | [deprecated] aggregate to ↑ |
| handle_call({:create_timer_with_executor_setting, {call_back, args, time, timer_name, limit, executor_settings}}, _from, {resources}) | [deprecated] aggregate to ↑ |

### Node module

| previous   | changed   |
| ----------- | ---------- |
| start_link({node, node_name}) | start_link({node, node_identifier, {queue_length, change_order}}) |
| start_link({node, node_name, :executor_setting, {queue_length}}) | [deprecated] aggregate to ↑ |
| start_link({node, node_name, :executor_setting, {queue_length, change_order}}) | [deprecated] aggregate to ↑ |
| start_link({node, node_name, node_namespace}) | [deprecated] aggregate to ↑ |
| start_link({node, node_name, node_namespace, :executor_setting, {queue_length}}) | [deprecated] aggregate to ↑ |
| start_link({node, node_name, node_namespace, :executor_setting, {queue_length, change_order}}) | [deprecated] aggregate to ↑ |
| init({node, node_name}) | init({node, node_identifier, queue_length, change_order}) |
| init({node, node_name, queue_length}) | [deprecated] aggregate to ↑ |
| init({node, node_name, queue_length, change_order}) | [deprecated] aggregate to ↑ |
| create_single_subscriber(node_identifier, msg_type, topic_name) | create_subscriber(node_identifier, msg_type, topic_name) |
| create_single_publisher(node_identifier, msg_type, topic_name) | create_publisher(node_identifier, msg_type, topic_name) |

### Timer module
| previous   | changed   |
| ----------- | ---------- |
| start_link({callback, args, time, timer_name}) | start_link({callback, args, time, timer_name, limit, executor_settings}) |
| start_link({callback, args, time, timer_name, limit}) | [deprecated] aggregate to ↑ |
| start_link({callback, args, time, timer_name, :executor_setting, executor_settings}) | [deprecated] aggregate to ↑ |
| start_link({callback, args, time, timer_name, limit, :executor_setting, executor_settings}) | [deprecated] aggregate to ↑ |
| init({callback, args, time, timer_name}) | init({callback, args, time, timer_name, limit, {queue_length, change_order}}) |
| init({callback, args, time, timer_name, limit})  | [deprecated] aggregate to ↑ |
| init({callback, args, time, timer_name, :executor_setting, {queue_length}}) | [deprecated] aggregate to ↑ |
| init({callback, args, time, timer_name, :executor_setting, {queue_length, change_order}}) | [deprecated] aggregate to ↑ |
| init({callback, args, time, timer_name, limit, :executor_setting, {queue_length}}) | [deprecated] aggregate to ↑ |
| init({callback, args, time, timer_name, limit, :executor_setting, {queue_length, change_order}}) | [deprecated] aggregate to ↑ |

### TimerLoop module
| previous   | changed   |
| ----------- | ---------- |
| start_link({timer_name, time}) | [deprecated] aggregate to start_link({timer_name, time, limit}) |
| init({timer_name, time}) | [deprecated] aggregate to init({timer_name, time, limit}) |
| handle_continue(:loop, {timer_name, time})  | [deprecated] aggregate to handle_continue(:loop, {timer_name, time, count, limit}) |
