### PR TITLE
add some unit tests to Subscriber

### DIFF
--- a/lib/rclex/subscriber.ex
+++ b/lib/rclex/subscriber.ex
@@ -65,8 +65,7 @@ defmodule Rclex.Subscriber do
 
     GenServer.cast(
       {:global, sub_identifier},
-      # FIXME: add topic_name to tuple
-      {:start_subscribing, {context, call_back, node_identifier}}
+      {:start_subscribing, {context, call_back, node_identifier, topic_name}}
     )
   end
 

--- a/test/rclex/subscriber_test.exs
+++ b/test/rclex/subscriber_test.exs
@@ -1,0 +1,40 @@
+defmodule Rclex.SubscriberTest do
+  use ExUnit.Case
+
+  alias Rclex.Subscriber
+
+  describe "start_subscribing/3" do
+    setup do
+      msg_type = 'StdMsgs.Msg.String'
+      node_id = 'node'
+      topic = 'topic'
+
+      dummy_subscriber_reference = make_ref()
+      subscriber_id = "#{node_id}/#{topic}/sub"
+
+      start_supervised!({Rclex.Subscriber, {dummy_subscriber_reference, msg_type, subscriber_id}})
+
+      %{subscriber: {node_id, topic, :sub}, context: Rclex.rclexinit(), callback: fn _ -> nil end}
+    end
+
+    @tag capture_log: true
+    test "for Subscriber.t(), return :ok", %{
+      subscriber: subscriber,
+      context: context,
+      callback: callback
+    } do
+      assert :ok = Subscriber.start_subscribing(subscriber, context, callback)
+      assert :ok = Subscriber.stop_subscribing(subscriber)
+    end
+
+    @tag capture_log: true
+    test "for [Subscriber.t()], return :ok", %{
+      subscriber: subscriber,
+      context: context,
+      callback: callback
+    } do
+      assert [:ok] = Subscriber.start_subscribing([subscriber], context, callback)
+      assert :ok = Subscriber.stop_subscribing(subscriber)
+    end
+  end
+end


### PR DESCRIPTION
タイトルままです。

[start_supervised!/2](https://hexdocs.pm/ex_unit/1.12/ExUnit.Callbacks.html#start_supervised!/2) を使い、Subscriberモジュールの単体テストを書いてみました。

テストのスコープを絞るためにNifsの関数使用も必要最小限にし、使用されないreferenceは`make_ref`関数でダミーのものを使用するようにしています。