### PR TITLE
exclude auto-generated files format

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,9 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs:
+    ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+    # expand wildcard path to list
+    |> Enum.flat_map(&Path.wildcard(&1, match_dot: true))
+    # exclude msgs, ex) lib/rclex/geometry_msgs/msg/*.ex
+    |> Enum.reject(fn path -> Regex.match?(~r{lib/rclex/.*/msg/.*}, path) end)
 ]


### PR DESCRIPTION
自動生成されるROSのメッセージ型のコードのフォーマットを exclude する方法を知ったので、追加しました。

refs) https://groups.google.com/g/elixir-lang-core/c/T7MMg1OF1aI

デメリットは将来的にフォーマットをかけたくなった時に、なぜフォーマットされないのを調べるのにちょっと時間を要しそうなことです。