### PR TITLE
supress debug log when RclexTest is invoked

### DIFF
--- a/test/rclex_test.exs
+++ b/test/rclex_test.exs
@@ -1,5 +1,7 @@
 defmodule RclexTest do
   use ExUnit.Case
+  @moduletag capture_log: true
+
   doctest Rclex
 
   describe "rclexinit/0" do


### PR DESCRIPTION
タイトルままです。

テストのコンソール出力はテストによるエラー以外を表示するとうるさくなってしまうので、出力しないようにしたいです。