### PR TITLE
fix node name bug, when it attributes a namespace (and also fix #142)

### DIFF
--- a/lib/rclex/resource_server.ex
+++ b/lib/rclex/resource_server.ex
@@ -196,10 +196,7 @@ defmodule Rclex.ResourceServer do
         {resources}
       ) do
     node_identifier_list =
-      0..(num_node - 1)
-      |> Enum.map(fn node_no ->
-        get_identifier(namespace, node_name) ++ Integer.to_charlist(node_no)
-      end)
+      for index <- 0..(num_node - 1), do: node_name ++ Integer.to_charlist(index)
 
     if Enum.any?(node_identifier_list, &Map.has_key?(resources, &1)) do
       # 同名のノードがすでに存在しているときはエラーを返す
@@ -302,16 +299,6 @@ defmodule Rclex.ResourceServer do
   def handle_info({_, _, reason}, state) do
     Logger.debug(reason)
     {:noreply, state}
-  end
-
-  @spec get_identifier(charlist(), charlist()) :: charlist()
-  defp get_identifier(node_namespace, node_name) do
-    if node_namespace != '' do
-      # FIXME: 'node name must not contain characters other than alphanumerics or '_'
-      "#{node_namespace}/#{node_name}" |> String.to_charlist()
-    else
-      node_name
-    end
   end
 
   @spec call_nifs_rcl_node_init(any(), charlist(), charlist(), context(), any()) :: any()

--- a/lib/rclex/resource_server.ex
+++ b/lib/rclex/resource_server.ex
@@ -195,18 +195,22 @@ defmodule Rclex.ResourceServer do
         _from,
         {resources}
       ) do
+    node_name_list = for index <- 0..(num_node - 1), do: node_name ++ Integer.to_charlist(index)
+
     node_identifier_list =
-      for index <- 0..(num_node - 1), do: node_name ++ Integer.to_charlist(index)
+      node_name_list
+      |> Enum.map(&get_identifier_name(&1, namespace))
 
     if Enum.any?(node_identifier_list, &Map.has_key?(resources, &1)) do
       # 同名のノードがすでに存在しているときはエラーを返す
       {:reply, :error, {resources}}
     else
       nodes_list =
-        node_identifier_list
-        # id -> {node, id}
-        |> Enum.map(fn node_identifier ->
-          {get_initialized_node(context, node_identifier, namespace), node_identifier}
+        node_name_list
+        # id -> {node, id(ns+name)}
+        |> Enum.map(fn node_name ->
+          {get_initialized_node(context, node_name, namespace),
+           get_identifier_name(node_name, namespace)}
         end)
         # {node, id} -> {id, {:ok, pid}}
         |> Enum.map(fn {node, node_identifier} ->
@@ -293,6 +297,14 @@ defmodule Rclex.ResourceServer do
   def handle_info({_, _, reason}, state) do
     Logger.debug(reason)
     {:noreply, state}
+  end
+
+  defp get_identifier_name(node_name, _node_namespace = '') do
+    node_name
+  end
+
+  defp get_identifier_name(node_name, node_namespace) do
+    node_namespace ++ '/' ++ node_name
   end
 
   @spec get_initialized_node(context(), charlist(), charlist(), reference(), reference()) ::

--- a/test/rclex/resource_server_test.exs
+++ b/test/rclex/resource_server_test.exs
@@ -20,7 +20,7 @@ defmodule Rclex.ResourceServerTest do
       node_name = 'node'
       namespace = 'namespace'
 
-      assert {:ok, 'namespace/node0'} =
+      assert {:ok, 'node0'} =
                ResourceServer.create_node_with_namespace(
                  context,
                  node_name,
@@ -60,7 +60,7 @@ defmodule Rclex.ResourceServerTest do
       namespace = 'namespace'
       node_count = 2
 
-      assert {:ok, ['namespace/node0', 'namespace/node1']} =
+      assert {:ok, ['node0', 'node1']} =
                ResourceServer.create_nodes_with_namespace(
                  context,
                  node_name,

--- a/test/rclex/resource_server_test.exs
+++ b/test/rclex/resource_server_test.exs
@@ -58,6 +58,7 @@ defmodule Rclex.ResourceServerTest do
     test "return {:ok, [node_id]}", %{context: context} do
       node_name = 'node'
       namespace = 'namespace'
+      another_namespace = 'namespace2'
       node_count = 2
 
       assert {:ok, ['namespace/node0', 'namespace/node1']} =
@@ -65,6 +66,22 @@ defmodule Rclex.ResourceServerTest do
                  context,
                  node_name,
                  namespace,
+                 node_count
+               )
+
+      assert :error =
+               ResourceServer.create_nodes_with_namespace(
+                 context,
+                 node_name,
+                 namespace,
+                 node_count
+               )
+
+      assert {:ok, ['namespace2/node0', 'namespace2/node1']} =
+               ResourceServer.create_nodes_with_namespace(
+                 context,
+                 node_name,
+                 another_namespace,
                  node_count
                )
     end

--- a/test/rclex/resource_server_test.exs
+++ b/test/rclex/resource_server_test.exs
@@ -20,7 +20,7 @@ defmodule Rclex.ResourceServerTest do
       node_name = 'node'
       namespace = 'namespace'
 
-      assert {:ok, 'node0'} =
+      assert {:ok, 'namespace/node0'} =
                ResourceServer.create_node_with_namespace(
                  context,
                  node_name,
@@ -60,7 +60,7 @@ defmodule Rclex.ResourceServerTest do
       namespace = 'namespace'
       node_count = 2
 
-      assert {:ok, ['node0', 'node1']} =
+      assert {:ok, ['namespace/node0', 'namespace/node1']} =
                ResourceServer.create_nodes_with_namespace(
                  context,
                  node_name,


### PR DESCRIPTION
This commit fixes below, so closes #142

```
>>> [rcutils|error_handling.c:108] rcutils_set_error_state()
This error state is being overwritten:

  'node name must not contain characters other than alphanumerics or '_', at /tmp/binarydeb/ros-foxy-rcl-1.1.13/src/rcl/node.c:164'

with this new error message:

  'subscription's implementation is invalid, at /tmp/binarydeb/ros-foxy-rcl-1.1.13/src/rcl/subscription.c:462'

rcutils_reset_error() should be called after error handling to avoid this.
<<<
```

本修正方法だと、ノード名に namespace を含まなくなります。
それが rclex の方針と異なるようであれば、修正案をご指示いただきたいです。
※ただし、rclのリソースとしてはnamespeceを保持する点は維持しています。

修正前： `"#{namespace}/#{node_id}"`
修正後: `"#{node_id}"`