### PR TITLE
add unit tests of Rclex.Nifs for init_nif, node_nif, publisher_nif, subscription_nif

### DIFF
--- a/lib/rclex/nifs.ex
+++ b/lib/rclex/nifs.ex
@@ -14,6 +14,10 @@ defmodule Rclex.Nifs do
   @type rosidl_message_type_support() :: reference()
   @type rmw_publisher_allocation() :: reference()
   @type ros_message() :: reference()
+  @type rcl_subscription_options() :: reference()
+  @type rcl_subscription() :: reference()
+  @type rmw_subscription_allocation() :: reference()
+  @type rmw_message_info() :: reference()
 
   def load_nifs do
     nif = Application.app_dir(:rclex, "priv/rclex_nifs")
@@ -151,40 +155,38 @@ defmodule Rclex.Nifs do
   end
 
   # ---------------------------subscription_nif.c--------------------------
-  def rcl_subscription_get_default_options do
+  @spec rcl_subscription_get_default_options() :: rcl_subscription_options()
+  def rcl_subscription_get_default_options() do
     :erlang.nif_error("NIF rcl_subscription_get_default_options is not implemented")
   end
 
-  def rcl_get_zero_initialized_subscription do
+  @type rcl_get_zero_initialized_subscription() :: rcl_subscription()
+  def rcl_get_zero_initialized_subscription() do
     :erlang.nif_error("NIF rcl_subscription_get_default_options is not implemented")
   end
 
-  def create_sub_alloc do
+  @spec create_sub_alloc() :: rmw_subscription_allocation()
+  def create_sub_alloc() do
     :erlang.nif_error("NIF create_suballoc/0 is not implemented")
   end
 
-  @doc """
-    rcl_ret_t
-    rcl_subscription_init(
-      rcl_subscription_t * subscription,
-      const rcl_node_t * node,
-      const rosidl_message_type_support_t * type_support,
-      const char * topic_name,
-      const rcl_subscription_options_t * options
-  );
-  """
+  @spec rcl_subscription_init(
+          rcl_subscription(),
+          rcl_node(),
+          topic_name :: charlist(),
+          rosidl_message_type_support(),
+          rcl_subscription_options()
+        ) :: rcl_subscription()
   def rcl_subscription_init(_a, _b, _c, _d, _e) do
     :erlang.nif_error("NIF rcl_subscription_init is not implemented")
   end
 
-  @doc """
-      return rcl_ret_t
-      argument...rcl_subscription_t*,rcl_node_t*
-  """
+  @spec rcl_subscription_fini(rcl_subscription(), rcl_node()) :: rcl_ret()
   def rcl_subscription_fini(_a, _b) do
     :erlang.nif_error("NIF rcl_subscription_fini is not implemented")
   end
 
+  @spec rcl_subscription_get_topic_name(rcl_subscription()) :: topic_name :: charlist()
   def rcl_subscription_get_topic_name(_a) do
     :erlang.nif_error("NIF rcl_subscription_get_topic_name/1 is not implemented")
   end
@@ -198,6 +200,14 @@ defmodule Rclex.Nifs do
       rmw_subscription_allocation_t * allocation
     );
   """
+  @spec rcl_take(
+          rcl_subscription(),
+          ros_message(),
+          rmw_message_info(),
+          rmw_subscription_allocation()
+        ) ::
+          {return_value :: integer(), rcl_subscription(), rmw_message_info(),
+           rmw_subscription_allocation()}
   def rcl_take(_a, _b, _c, _d) do
     :erlang.nif_error("NIF rcl_take is not implemented")
   end

--- a/lib/rclex/nifs.ex
+++ b/lib/rclex/nifs.ex
@@ -4,6 +4,17 @@ defmodule Rclex.Nifs do
 
   @moduledoc false
 
+  @type rcl_init_options() :: reference()
+  @type rcl_context() :: reference()
+  @type rcl_ret() :: reference()
+  @type rcl_node() :: reference()
+  @type rcl_node_options() :: reference()
+  @type rcl_publisher() :: reference()
+  @type rcl_publisher_options() :: reference()
+  @type rosidl_message_type_support() :: reference()
+  @type rmw_publisher_allocation() :: reference()
+  @type ros_message() :: reference()
+
   def load_nifs do
     nif = Application.app_dir(:rclex, "priv/rclex_nifs")
 
@@ -12,157 +23,129 @@ defmodule Rclex.Nifs do
 
   # -----------------------init_nif.c--------------------------
 
-  def rcl_get_zero_initialized_init_options do
+  @spec rcl_get_zero_initialized_init_options() :: rcl_init_options()
+  def rcl_get_zero_initialized_init_options() do
     :erlang.nif_error("NIF rcl_get_zero_initialized_init_options/0 not implemented")
   end
 
+  @spec rcl_init_options_init(rcl_init_options()) :: :ok
   def rcl_init_options_init(_a) do
     :erlang.nif_error("NIF rcl_init_options_init/1 is not implemented")
   end
 
+  @spec rcl_init_options_fini(rcl_init_options()) :: rcl_init_options()
   def rcl_init_options_fini(_a) do
     :erlang.nif_error("NIF rcl_init_options_fini/1 is not implemented")
   end
 
+  @spec rcl_get_zero_initialized_context() :: rcl_context()
   def rcl_get_zero_initialized_context do
     :erlang.nif_error("NIF rcl_get_zero_initialized_context/0 not implemented")
   end
 
-  @doc """
-      return {:ok,rcl_ret_t}
-      arguments...(
-          int argc,
-          char const * const * argv,
-          const rcl_init_options_t * options,
-          rcl_context_t * context)
-        argc,argvに0,NULLを直接入れる関数
-  """
+  @spec rcl_init_with_null(rcl_init_options(), rcl_context()) :: rcl_ret()
   def rcl_init_with_null(_a, _b) do
     :erlang.nif_error("NIF rcl_init_with_null/2 not implemented")
   end
 
-  @doc """
-      return {:ok,rcl_ret_t}
-      arguments...(
-          rcl_context_t)
-  """
+  @spec rcl_shutdown(rcl_context()) :: {:ok, rcl_context()}
   def rcl_shutdown(_a) do
     :erlang.nif_error("NIF rcl_shutdown/1 not implemented")
   end
 
   # -----------------------node_nif.c--------------------------
-  # return {:ok,rcl_node_t}
+  @spec rcl_get_zero_initialized_node() :: rcl_node()
   def rcl_get_zero_initialized_node do
     :erlang.nif_error("NIF rcl_get_zero_initialized_node/0 not implemented")
   end
 
-  # return {:ok,rcl_node_options_t}
+  @spec rcl_node_get_default_options() :: rcl_node_options()
   def rcl_node_get_default_options do
     :erlang.nif_error("NIF rcl_node_get_default_options/0 not implemented")
   end
 
-  @doc """
-      return {:ok,rcl_ret_t}
-      argument...(
-      rcl_node_t * node,
-      const char * name,
-      const char * namespace_,
-      rcl_context_t * context,
-      const rcl_node_options_t * options)
-  """
+  @spec rcl_node_init(
+          rcl_node(),
+          node_name :: charlist(),
+          node_namespace :: charlist(),
+          rcl_context(),
+          rcl_node_options()
+        ) ::
+          rcl_node()
   def rcl_node_init(_a, _b, _c, _d, _e) do
     :erlang.nif_error("NIF rcl_node_init/5 not implemented")
   end
 
+  @spec rcl_node_init_without_namespace(
+          rcl_node(),
+          node_name :: charlist(),
+          rcl_context(),
+          rcl_node_options()
+        ) ::
+          rcl_node()
   def rcl_node_init_without_namespace(_a, _b, _c, _d) do
     :erlang.nif_error("NIF rcl_node_init_without_namespace/4 is not implemented")
   end
 
-  @doc """
-      return rcl_ret_t
-      argument...rcl_node_t
-  """
+  @spec rcl_node_fini(rcl_node()) :: rcl_ret()
   def rcl_node_fini(_a) do
     :erlang.nif_error("NIF rcl_node_fini/1 not implemented")
   end
 
+  # TODO: 機能のない関数であれば削除すること
   def read_guard_condition(_a) do
     :erlang.nif_error("haha")
   end
 
-  @doc """
-      return char
-  """
-
+  @spec rcl_node_get_name(rcl_node()) :: node_name :: charlist()
   def rcl_node_get_name(_a) do
     :erlang.nif_error("NIF rcl_node_get_name/1 not implemented")
   end
 
   # ------------------------------publisher_nif.c--------------------------
-  @doc """
-      return rcl_publisher_t
-      argument...void
-  """
-  def rcl_get_zero_initialized_publisher do
+  @spec rcl_get_zero_initialized_publisher() :: rcl_publisher()
+  def rcl_get_zero_initialized_publisher() do
     :erlang.nif_error("NIF get_zero_initialized_publisher/0 not implemented")
   end
 
-  @doc """
-      return rcl_publisher_options_t
-      argument...void
-  """
-  def rcl_publisher_get_default_options do
+  @spec rcl_publisher_get_default_options() :: rcl_publisher_options()
+  def rcl_publisher_get_default_options() do
     :erlang.nif_error("rcl_get_zero_initialized_publisher/0 not implemented")
   end
 
-  @doc """
-      return const char*
-      argument...rcl_publisher_t*
-  """
+  @spec rcl_publisher_get_topic_name(rcl_publisher()) :: topic_name :: charlist()
   def rcl_publisher_get_topic_name(_a) do
     :erlang.nif_error("rcl_get_zero_initialized_publisher/0 not implemented")
   end
 
-  @doc """
-      return rcl_ret_t
-      argument...rcl_publisher_t*,rcl_node_t*
-  """
+  @spec rcl_publisher_fini(rcl_publisher(), rcl_node()) :: rcl_ret()
   def rcl_publisher_fini(_a, _b) do
     :erlang.nif_error("rcl_get_zero_initialized_publisher/0 not implemented")
   end
 
-  @doc """
-      return rcl_ret_t
-      argument...rcl_publisher_t * publisher,
-                  const rcl_node_t * node,
-                  const rosidl_message_type_support_t * type_support,
-                  const char * topic_name,
-                  const rcl_publisher_options_t * options
-  """
+  @spec rcl_publisher_init(
+          rcl_publisher(),
+          rcl_node(),
+          topic_name :: charlist(),
+          rosidl_message_type_support(),
+          rcl_publisher_options()
+        ) :: rcl_publisher()
   def rcl_publisher_init(_a, _b, _c, _d, _e) do
     :erlang.nif_error("rcl_publisher_init/4 not implemented")
   end
 
-  @doc """
-      return bool
-      argument...rcl_publisher_t*
-  """
+  @spec rcl_publisher_is_valid(rcl_publisher()) :: boolean()
   def rcl_publisher_is_valid(_a) do
     :erlang.nif_error("rcl_publisher_is_valid/1 not implemented")
   end
 
-  @doc """
-    rcl_ret_t
-    rcl_publish(
-      const rcl_publisher_t * publisher,
-      const void * ros_message,
-      rmw_publisher_allocation_t * allocation
-    );
-  """
+  @spec rcl_publish(rcl_publisher(), ros_message(), rmw_publisher_allocation()) ::
+          {return_value :: integer(), rcl_publisher(), rmw_publisher_allocation()}
   def rcl_publish(_a, _b, _c) do
     :erlang.nif_error("rcl_publish/3 is not implemented")
   end
 
+  @spec create_pub_alloc() :: rmw_publisher_allocation()
   def create_pub_alloc do
     :erlang.nif_error("NIF create_pub_alloc/0 is not implemented")
   end

--- a/test/rclex/nifs_test.exs
+++ b/test/rclex/nifs_test.exs
@@ -1,0 +1,214 @@
+defmodule Rclex.NifsTest do
+  use ExUnit.Case
+
+  require Rclex.ReturnCode
+
+  alias Rclex.Nifs
+
+  describe "rcl_get_zero_initialized_init_options/0" do
+    test "return reference" do
+      assert is_reference(Nifs.rcl_get_zero_initialized_init_options())
+    end
+  end
+
+  describe "rcl_init_options_init/1" do
+    test "return :ok" do
+      assert :ok =
+               Nifs.rcl_get_zero_initialized_init_options()
+               |> Nifs.rcl_init_options_init()
+    end
+
+    test "raise ArgumentError" do
+      assert_raise ArgumentError, fn ->
+        make_ref()
+        |> Nifs.rcl_init_options_init()
+      end
+    end
+  end
+
+  describe "rcl_init_options_fini/1" do
+    test "return reference" do
+      options = Nifs.rcl_get_zero_initialized_init_options()
+      :ok = Nifs.rcl_init_options_init(options)
+      assert is_reference(Nifs.rcl_init_options_fini(options))
+    end
+  end
+
+  describe "rcl_get_zero_initialized_context/0" do
+    test "return reference" do
+      assert is_reference(Nifs.rcl_get_zero_initialized_context())
+    end
+  end
+
+  describe "rcl_init_with_null/2" do
+    test "return reference" do
+      init_options = Nifs.rcl_get_zero_initialized_init_options()
+      context = Nifs.rcl_get_zero_initialized_context()
+      assert is_reference(Nifs.rcl_init_with_null(init_options, context))
+    end
+  end
+
+  describe "rcl_shutdown/1" do
+    test "return {:ok, reference}" do
+      context = get_initialized_context()
+
+      assert {:ok, context} = Nifs.rcl_shutdown(context)
+      assert is_reference(context)
+    end
+  end
+
+  describe "rcl_get_zero_initialized_node/0" do
+    test "return reference" do
+      assert is_reference(Nifs.rcl_get_zero_initialized_node())
+    end
+  end
+
+  describe "rcl_node_get_default_options/0" do
+    test "return reference" do
+      assert is_reference(Nifs.rcl_node_get_default_options())
+    end
+  end
+
+  describe "rcl_node_init/5" do
+    test "return reference" do
+      node = Nifs.rcl_get_zero_initialized_node()
+      node_name = 'node'
+      node_namespace = 'namespace'
+      context = get_initialized_context()
+      options = Nifs.rcl_node_get_default_options()
+
+      assert is_reference(Nifs.rcl_node_init(node, node_name, node_namespace, context, options))
+    end
+  end
+
+  describe "rcl_node_init_without_namespace/4" do
+    test "return reference" do
+      node = Nifs.rcl_get_zero_initialized_node()
+      node_name = 'node'
+      context = get_initialized_context()
+      options = Nifs.rcl_node_get_default_options()
+
+      assert is_reference(Nifs.rcl_node_init_without_namespace(node, node_name, context, options))
+    end
+  end
+
+  describe "rcl_node_fini/1" do
+    test "return reference" do
+      node = get_initialized_no_namespace_node()
+      assert is_reference(Nifs.rcl_node_fini(node))
+    end
+  end
+
+  describe "rcl_node_get_name/1" do
+    test "return charlist" do
+      node_name = 'test'
+      node = get_initialized_no_namespace_node(node_name)
+      assert ^node_name = Nifs.rcl_node_get_name(node)
+    end
+  end
+
+  describe "rcl_get_zero_initialized_publisher/0" do
+    test "return reference" do
+      assert is_reference(Nifs.rcl_get_zero_initialized_publisher())
+    end
+  end
+
+  describe "rcl_publisher_get_default_options/0" do
+    test "return reference" do
+      assert is_reference(Nifs.rcl_publisher_get_default_options())
+    end
+  end
+
+  describe "rcl_publisher_fini/2" do
+    test "return reference" do
+      node = get_initialized_no_namespace_node()
+      publihser = get_initialized_publisher(node)
+
+      assert is_reference(Nifs.rcl_publisher_fini(publihser, node))
+    end
+  end
+
+  describe "rcl_publisher_init/5" do
+    test "reutrn reference" do
+      publisher = Nifs.rcl_get_zero_initialized_publisher()
+      node = get_initialized_no_namespace_node()
+      topic = 'topic'
+      typesupport = Rclex.Msg.typesupport('StdMsgs.Msg.String')
+      publisher_options = Nifs.rcl_publisher_get_default_options()
+
+      assert is_reference(
+               Nifs.rcl_publisher_init(publisher, node, topic, typesupport, publisher_options)
+             )
+    end
+  end
+
+  describe "rcl_publisher_is_valid/1" do
+    test "return true" do
+      node = get_initialized_no_namespace_node()
+      publisher = get_initialized_publisher(node)
+
+      assert true = Nifs.rcl_publisher_is_valid(publisher)
+    end
+  end
+
+  describe "rcl_publish/3" do
+    test "" do
+      node = get_initialized_no_namespace_node()
+      publisher = get_initialized_publisher(node)
+      publisher_allocation = Nifs.create_pub_alloc()
+
+      message = Rclex.Msg.initialize('StdMsgs.Msg.String')
+
+      :ok =
+        Rclex.Msg.set(
+          message,
+          %Rclex.StdMsgs.Msg.String{data: 'data'},
+          'StdMsgs.Msg.String'
+        )
+
+      rcl_ret_ok = Rclex.ReturnCode.rcl_ret_ok()
+
+      assert {^rcl_ret_ok, publisher, publisher_allocation} =
+               Nifs.rcl_publish(publisher, message, publisher_allocation)
+
+      assert is_reference(publisher)
+      assert is_reference(publisher_allocation)
+    end
+  end
+
+  describe "create_pub_alloc/0" do
+    test "return reference" do
+      assert is_reference(Nifs.create_pub_alloc())
+    end
+  end
+
+  defp get_initialized_context() do
+    options = Nifs.rcl_get_zero_initialized_init_options()
+    :ok = Nifs.rcl_init_options_init(options)
+    context = Nifs.rcl_get_zero_initialized_context()
+    Nifs.rcl_init_with_null(options, context)
+    Nifs.rcl_init_options_fini(options)
+
+    context
+  end
+
+  defp get_initialized_no_namespace_node(node_name \\ 'node') do
+    node = Nifs.rcl_get_zero_initialized_node()
+    context = get_initialized_context()
+    options = Nifs.rcl_node_get_default_options()
+
+    Nifs.rcl_node_init_without_namespace(node, node_name, context, options)
+  end
+
+  defp get_initialized_publisher(
+         node,
+         topic \\ 'topic',
+         message_type \\ 'StdMsgs.Msg.String',
+         publisher_options \\ Nifs.rcl_publisher_get_default_options()
+       ) do
+    publisher = Nifs.rcl_get_zero_initialized_publisher()
+    typesupport = Rclex.Msg.typesupport(message_type)
+
+    Nifs.rcl_publisher_init(publisher, node, topic, typesupport, publisher_options)
+  end
+end


### PR DESCRIPTION
タイトルままです。

doc タグは関数の引数と返り値を示すために使用されているようでしが、 spec タグで 引数と返り値を明示できるため削除しました。

ダーッとコードを書いてしまってからコミットを細かくするのを忘れていたことに気づいてしまったので、コミット粒度が大きくてすみません。
既存コードへの単体テスト追加のみですので、挙動への影響はありません。