### PR TITLE
fix flaky tests which is caused by too short time for waiting GenServer.cast process

### DIFF
--- a/test/rclex/timer_test.exs
+++ b/test/rclex/timer_test.exs
@@ -31,7 +31,7 @@ defmodule Rclex.TimerTest do
       assert capture_log(fn ->
                :ok = GenServer.cast(name, {:execute, nil})
                # wait execution of callback
-               Process.sleep(1)
+               Process.sleep(10)
              end) =~ callback_args
     end
   end
@@ -43,7 +43,7 @@ defmodule Rclex.TimerTest do
           :ok = GenServer.cast(name, {:stop, nil})
 
           # wait terminate(:normal, _)
-          Process.sleep(1)
+          Process.sleep(10)
         end)
 
       assert log =~ "the number of timer loop reaches limit"


### PR DESCRIPTION
`GenServer.cast` 後のログ出力で、動作確認をするテストですが待ち時間を 1ms として設定したのが短すぎたため、テストが flaky になっていました。

対処として、テスト時間に影響しない範囲で 1ms -> 10ms に延長しました。
※ハードコードな時間に依存している点が良くないのですが、とりあえず暫定処置とします。