### PR TITLE
Feat add publisher unit tests

### DIFF
--- a/lib/rclex/publisher.ex
+++ b/lib/rclex/publisher.ex
@@ -15,6 +15,7 @@ defmodule Rclex.Publisher do
   @type id_tuple() :: {node_identifier :: charlist(), topic_name :: charlist(), :pub}
 
   @doc false
+  @spec start_link({Nifs.rcl_publisher(), String.t()}) :: GenServer.on_start()
   def start_link({pub, process_name}) do
     GenServer.start_link(__MODULE__, pub, name: {:global, process_name})
   end

--- a/lib/rclex/publisher.ex
+++ b/lib/rclex/publisher.ex
@@ -12,7 +12,7 @@ defmodule Rclex.Publisher do
   * `Rclex.Node.create_publishers/4`
   """
 
-  @type t() :: {node_identifier :: charlist(), topic_name :: charlist(), :pub}
+  @type id_tuple() :: {node_identifier :: charlist(), topic_name :: charlist(), :pub}
 
   @doc false
   def start_link({pub, process_name}) do
@@ -45,7 +45,7 @@ defmodule Rclex.Publisher do
   end
 
   # TODO: define message type for reference()
-  @spec publish(publisher_list :: [t()], data :: [reference()]) :: :ok
+  @spec publish(publisher_list :: [id_tuple()], data :: [reference()]) :: :ok
   def publish(publisher_list, data) do
     n = length(publisher_list)
 

--- a/test/rclex/publisher_test.exs
+++ b/test/rclex/publisher_test.exs
@@ -13,11 +13,15 @@ defmodule Rclex.PublisherTest do
 
     context = get_initialized_context()
     node = get_initialized_no_namespace_node(context, node_id)
-
     publisher = get_initialized_publisher(node, topic, msg_type)
 
-    publisher_id = "#{node_id}/#{topic}/pub"
+    on_exit(fn ->
+      Nifs.rcl_publisher_fini(publisher, node)
+      Nifs.rcl_node_fini(node)
+      Nifs.rcl_shutdown(context)
+    end)
 
+    publisher_id = "#{node_id}/#{topic}/pub"
     pid = start_supervised!({Rclex.Publisher, {publisher, publisher_id}})
 
     %{publisher: publisher, id_tuple: {node_id, topic, :pub}, pid: pid, node: node}

--- a/test/rclex/publisher_test.exs
+++ b/test/rclex/publisher_test.exs
@@ -1,0 +1,113 @@
+defmodule Rclex.PublisherTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureLog
+
+  alias Rclex.Publisher
+  alias Rclex.Nifs
+
+  setup do
+    msg_type = 'StdMsgs.Msg.String'
+    node_id = 'node'
+    topic = 'topic'
+
+    context = get_initialized_context()
+    node = get_initialized_no_namespace_node(context, node_id)
+
+    publisher = get_initialized_publisher(node, topic, msg_type)
+
+    publisher_id = "#{node_id}/#{topic}/pub"
+
+    pid = start_supervised!({Rclex.Publisher, {publisher, publisher_id}})
+
+    %{publisher: publisher, id_tuple: {node_id, topic, :pub}, pid: pid, node: node}
+  end
+
+  describe "publish_once/3" do
+    test "capture_log", %{publisher: publisher} do
+      publisher_allocation = Nifs.create_pub_alloc()
+
+      message = Rclex.Msg.initialize('StdMsgs.Msg.String')
+
+      :ok =
+        Rclex.Msg.set(
+          message,
+          %Rclex.StdMsgs.Msg.String{data: 'data'},
+          'StdMsgs.Msg.String'
+        )
+
+      assert capture_log(fn ->
+               Publisher.publish_once(publisher, message, publisher_allocation)
+             end) =~ "publish ok"
+    end
+  end
+
+  describe "publish/2" do
+    @tag capture_log: true
+    test "return :ok", %{id_tuple: id_tuple} do
+      message = Rclex.Msg.initialize('StdMsgs.Msg.String')
+
+      :ok =
+        Rclex.Msg.set(
+          message,
+          %Rclex.StdMsgs.Msg.String{data: 'data'},
+          'StdMsgs.Msg.String'
+        )
+
+      assert :ok = Publisher.publish([id_tuple], [message])
+    end
+  end
+
+  describe "handle_cast({:publish, msg}, pub)" do
+    test "capture_log", %{pid: pid} do
+      message = Rclex.Msg.initialize('StdMsgs.Msg.String')
+
+      :ok =
+        Rclex.Msg.set(
+          message,
+          %Rclex.StdMsgs.Msg.String{data: 'data'},
+          'StdMsgs.Msg.String'
+        )
+
+      assert capture_log(fn ->
+               GenServer.cast(pid, {:publish, message})
+               Process.sleep(10)
+             end) =~ "publish ok"
+    end
+  end
+
+  describe "handle_call({:finish, node}, ...)" do
+    test "return", %{pid: pid, node: node} do
+      assert {:ok, 'publisher finished: '} = GenServer.call(pid, {:finish, node})
+    end
+  end
+
+  defp get_initialized_context() do
+    options = Nifs.rcl_get_zero_initialized_init_options()
+    :ok = Nifs.rcl_init_options_init(options)
+    context = Nifs.rcl_get_zero_initialized_context()
+    Nifs.rcl_init_with_null(options, context)
+    Nifs.rcl_init_options_fini(options)
+
+    context
+  end
+
+  defp get_initialized_no_namespace_node(context, node_name \\ 'node') do
+    node = Nifs.rcl_get_zero_initialized_node()
+    options = Nifs.rcl_node_get_default_options()
+
+    Nifs.rcl_node_init_without_namespace(node, node_name, context, options)
+  end
+
+  defp get_initialized_publisher(
+         node,
+         topic \\ 'topic',
+         message_type \\ 'StdMsgs.Msg.String',
+         publisher_options \\ Nifs.rcl_publisher_get_default_options()
+       ) do
+    publisher = Nifs.rcl_get_zero_initialized_publisher()
+    typesupport = Rclex.Msg.typesupport(message_type)
+
+    Nifs.rcl_publisher_init(publisher, node, topic, typesupport, publisher_options)
+  end
+end


### PR DESCRIPTION
本PRは以下のような flaky なテストを含みます。

```
  1) test publish_once/3 capture_log (Rclex.PublisherTest)
     test/rclex/publisher_test.exs:27
     Assertion with =~ failed
     code:  assert capture_log(fn -> Publisher.publish_once(publisher, message, publisher_allocation) end) =~ "publish ok"
     left:  "\e[31m\n00:34:26.988 [error] Publisher is invalid\n\e[0m"
     right: "publish ok"
     stacktrace:
       test/rclex/publisher_test.exs:39: (test)
```

上記が起きる契機は、 `Rclex.Publisher.publish_once/3` 実行時に 以下が返ることがあるためです。
https://github.com/rclex/rclex/blob/99a080d0833b8c5ced8712cefb509e48e4c309be/lib/rclex/publisher.ex#L34-L35

原因は今のところ不明です。