### PR TITLE
Fix specs

### DIFF
--- a/lib/rclex.ex
+++ b/lib/rclex.ex
@@ -6,14 +6,10 @@ defmodule Rclex do
   Defines functions to manage ROS client resources.
   """
 
-  @type rcl_context :: reference()
-  @type rcl_allocator :: reference()
-  @type rcl_ret :: reference()
-
   @doc """
   Initialize Rclex, return initialized context.
   """
-  @spec rclexinit() :: rcl_context()
+  @spec rclexinit() :: Nifs.rcl_context()
   def rclexinit() do
     children = [Rclex.ResourceServer]
     opts = [strategy: :one_for_one, name: :resource_server]
@@ -23,7 +19,7 @@ defmodule Rclex do
     get_initialized_context()
   end
 
-  @spec get_initialized_context() :: rcl_context()
+  @spec get_initialized_context() :: Nifs.rcl_context()
   def get_initialized_context() do
     init_op = Nifs.rcl_get_zero_initialized_init_options()
     context = Nifs.rcl_get_zero_initialized_context()
@@ -55,7 +51,7 @@ defmodule Rclex do
   this function does not have to be called on exit,
   but does have to be called making a repeat call to rclexinit.
   """
-  @spec shutdown(context :: reference()) :: {:ok, rcl_ret()}
+  @spec shutdown(context :: reference()) :: {:ok, Nifs.rcl_ret()}
   def shutdown(context) when is_reference(context) do
     Supervisor.stop(:resource_server)
     Nifs.rcl_shutdown(context)
@@ -64,7 +60,7 @@ defmodule Rclex do
   @doc """
   Return a properly initialized allocator with default values.
   """
-  @spec get_default_allocator :: rcl_allocator()
+  @spec get_default_allocator :: Nifs.rcl_allocator()
   def get_default_allocator do
     Nifs.rcl_get_default_allocator()
   end

--- a/lib/rclex.ex
+++ b/lib/rclex.ex
@@ -20,7 +20,7 @@ defmodule Rclex do
   end
 
   @spec get_initialized_context() :: Nifs.rcl_context()
-  def get_initialized_context() do
+  defp get_initialized_context() do
     init_op = Nifs.rcl_get_zero_initialized_init_options()
     context = Nifs.rcl_get_zero_initialized_context()
     Nifs.rcl_init_options_init(init_op)

--- a/lib/rclex/job_executor.ex
+++ b/lib/rclex/job_executor.ex
@@ -7,10 +7,9 @@ defmodule Rclex.JobExecutor do
 
   * The execution order can be changed by using the change order function.
     * change order function receives list(), return list()
-  """
 
-  @doc false
-  def start_link(state)
+  Used by `Rclex.Timer` and `Rclex.Subscriber`.
+  """
 
   @spec start_link({target_identifier :: charlist()}) :: GenServer.on_start()
   def start_link({target_identifier}) do

--- a/lib/rclex/job_executor.ex
+++ b/lib/rclex/job_executor.ex
@@ -12,10 +12,13 @@ defmodule Rclex.JobExecutor do
   @doc false
   def start_link(state)
 
+  @spec start_link({target_identifier :: charlist()}) :: GenServer.on_start()
   def start_link({target_identifier}) do
     GenServer.start_link(__MODULE__, {}, name: {:global, "#{target_identifier}/JobExecutor"})
   end
 
+  @spec start_link({target_identifier :: charlist(), change_order :: (list() -> list())}) ::
+          GenServer.on_start()
   def start_link({target_identifier, change_order}) do
     GenServer.start_link(__MODULE__, {change_order},
       name: {:global, "#{target_identifier}/JobExecutor"}

--- a/lib/rclex/job_queue.ex
+++ b/lib/rclex/job_queue.ex
@@ -7,6 +7,8 @@ defmodule Rclex.JobQueue do
 
   * queue length is changeable
     * if not specified the length to be 1
+
+  Used by `Rclex.Timer` and `Rclex.Subscriber`.
   """
 
   # FIXME: below comment feature is not implemented

--- a/lib/rclex/job_queue.ex
+++ b/lib/rclex/job_queue.ex
@@ -12,12 +12,15 @@ defmodule Rclex.JobQueue do
   # FIXME: below comment feature is not implemented
   # queue_lengthが-1なら外部から呼ばれるまでqueueをため続ける
 
+  @spec start_link({target_identifier :: charlist()}) :: GenServer.on_start()
   def start_link({target_identifier}) do
     GenServer.start_link(__MODULE__, {target_identifier, 1},
       name: {:global, "#{target_identifier}/JobQueue"}
     )
   end
 
+  @spec start_link({target_identifier :: charlist(), queue_length :: integer()}) ::
+          GenServer.on_start()
   def start_link({target_identifier, queue_length}) do
     GenServer.start_link(__MODULE__, {target_identifier, queue_length},
       name: {:global, "#{target_identifier}/JobQueue"}

--- a/lib/rclex/msg.ex
+++ b/lib/rclex/msg.ex
@@ -3,10 +3,12 @@ defmodule Rclex.Msg do
   Defines functions which call `Rclex.MsgProt` implementation.
   """
 
+  alias Rclex.Nifs
+
   @doc """
   Return typesupport reference.
   """
-  @spec typesupport(msg_type :: charlist()) :: reference()
+  @spec typesupport(msg_type :: charlist()) :: Nifs.rosidl_message_type_support()
   def typesupport(msg_type) do
     get_struct(msg_type) |> Rclex.MsgProt.typesupport()
   end
@@ -14,7 +16,7 @@ defmodule Rclex.Msg do
   @doc """
   Return reference which refers to initialized msg_type C struct instance.
   """
-  @spec initialize(msg_type :: charlist()) :: reference()
+  @spec initialize(msg_type :: charlist()) :: Nifs.ros_message()
   def initialize(msg_type) do
     get_struct(msg_type) |> Rclex.MsgProt.initialize()
   end
@@ -22,7 +24,7 @@ defmodule Rclex.Msg do
   @doc """
   Return list of reference which refers to initialized msg_type C struct instance.
   """
-  @spec initialize_msgs(msg_count :: integer(), msg_type :: charlist()) :: [reference()]
+  @spec initialize_msgs(msg_count :: integer(), msg_type :: charlist()) :: [Nifs.ros_message()]
   def initialize_msgs(msg_count, msg_type) do
     str = get_struct(msg_type)
 
@@ -34,7 +36,7 @@ defmodule Rclex.Msg do
   @doc """
   Set Elixir struct to C struct instance.
   """
-  @spec set(msg :: reference(), data :: struct(), _msg_type :: charlist()) :: :ok
+  @spec set(msg :: Nifs.ros_message(), data :: struct(), _msg_type :: charlist()) :: :ok
   def set(msg, data, _msg_type) do
     Rclex.MsgProt.set(data, msg)
   end
@@ -42,7 +44,7 @@ defmodule Rclex.Msg do
   @doc """
   Return msg_type struct loaded with data from C struct instance.
   """
-  @spec read(msg :: reference(), msg_type :: charlist()) :: struct()
+  @spec read(msg :: Nifs.ros_message(), msg_type :: charlist()) :: struct()
   def read(msg, msg_type) do
     get_struct(msg_type) |> Rclex.MsgProt.read(msg)
   end

--- a/lib/rclex/msg_prot.ex
+++ b/lib/rclex/msg_prot.ex
@@ -4,27 +4,29 @@ defprotocol Rclex.MsgProt do
   Modules implementing this protocol should define relationships between Elixir structure data and C structure data.
   """
 
+  alias Rclex.Nifs
+
   @doc """
   Should return typesupport reference.
   """
-  @spec typesupport(msg_type :: struct()) :: reference()
+  @spec typesupport(msg_type :: struct()) :: Nifs.rosidl_message_type_support()
   def typesupport(msg_type)
 
   @doc """
   Should return reference to C struct instance.
   """
-  @spec initialize(msg_type :: struct()) :: reference()
+  @spec initialize(msg_type :: struct()) :: Nifs.ros_message()
   def initialize(msg_type)
 
   @doc """
   Should set Elixir struct to C struct instance.
   """
-  @spec set(data :: struct(), msg :: reference()) :: :ok
+  @spec set(data :: struct(), msg :: Nifs.ros_message()) :: :ok
   def set(data, msg)
 
   @doc """
   Should return Elixir struct loaded with data from C struct instance.
   """
-  @spec read(msg_type :: struct(), msg :: reference()) :: struct()
+  @spec read(msg_type :: struct(), msg :: Nifs.ros_message()) :: struct()
   def read(msg_type, msg)
 end

--- a/lib/rclex/nifs.ex
+++ b/lib/rclex/nifs.ex
@@ -18,6 +18,7 @@ defmodule Rclex.Nifs do
   @type rcl_subscription() :: reference()
   @type rmw_subscription_allocation() :: reference()
   @type rmw_message_info() :: reference()
+  @type rcl_allocator() :: reference()
 
   def load_nifs do
     nif = Application.app_dir(:rclex, "priv/rclex_nifs")
@@ -226,7 +227,8 @@ defmodule Rclex.Nifs do
   end
 
   # -----------------------------wait_nif.c------------------------------
-  def rcl_get_default_allocator do
+  @spec rcl_get_default_allocator() :: rcl_allocator()
+  def rcl_get_default_allocator() do
     :erlang.nif_error("NIF rcl_get_default_allocator/0 is not implemented")
   end
 

--- a/lib/rclex/publisher.ex
+++ b/lib/rclex/publisher.ex
@@ -21,11 +21,14 @@ defmodule Rclex.Publisher do
   end
 
   @impl GenServer
+  @spec init(Nifs.rcl_publisher()) :: {:ok, Nifs.rcl_publisher()}
   def init(pub) do
     {:ok, pub}
   end
 
   # FIXME?: 公開されていない内部状態変数 pub を使用するので defp とするべき？
+  @spec publish_once(Nifs.rcl_publisher(), Nifs.ros_message(), Nifs.rmw_publisher_allocation()) ::
+          :ok
   def publish_once(pub, pubmsg, pub_alloc) do
     case Nifs.rcl_publish(pub, pubmsg, pub_alloc) do
       {Rclex.ReturnCode.rcl_ret_ok(), _, _} ->
@@ -46,7 +49,7 @@ defmodule Rclex.Publisher do
   end
 
   # TODO: define message type for reference()
-  @spec publish(publisher_list :: [id_tuple()], data :: [reference()]) :: :ok
+  @spec publish(publisher_list :: [id_tuple()], data :: [Nifs.ros_message()]) :: :ok
   def publish(publisher_list, data) do
     n = length(publisher_list)
 

--- a/lib/rclex/resource_server.ex
+++ b/lib/rclex/resource_server.ex
@@ -3,9 +3,6 @@ defmodule Rclex.ResourceServer do
   require Logger
   use GenServer, restart: :transient
 
-  # TODO: replece any() with Rclex.rcl_contest()
-  @type context :: any()
-
   @moduledoc """
   Defines functions to manage ROS resources, Node and Timer.
   """
@@ -23,6 +20,7 @@ defmodule Rclex.ResourceServer do
           keyがnode_identifer、valueがnode情報。現在はnodeプロセスのsupervisorのidを格納している
   """
   @impl GenServer
+  @spec init(any()) :: {:ok, {map()}}
   def init(_) do
     {:ok, {%{}}}
   end
@@ -31,7 +29,7 @@ defmodule Rclex.ResourceServer do
   Create specified name single Node without namespace.
   This function calls `create_node_with_namespace/5` with namespace = ''.
   """
-  @spec create_node(context(), charlist(), integer(), (list() -> list())) ::
+  @spec create_node(Nifs.rcl_context(), charlist(), integer(), (list() -> list())) ::
           {:ok, node_identifier :: charlist()}
   def create_node(context, node_name, queue_length \\ 1, change_order \\ & &1) do
     create_node_with_namespace(context, node_name, '', queue_length, change_order)
@@ -49,7 +47,7 @@ defmodule Rclex.ResourceServer do
   * change_order: function which change the order of job
   """
   @spec create_node_with_namespace(
-          context(),
+          Nifs.rcl_context(),
           charlist(),
           charlist(),
           integer(),
@@ -75,7 +73,7 @@ defmodule Rclex.ResourceServer do
   Create specified name multiple Nodes without namespace.
   This function calls `create_nodes_with_namespace/6` with node_namespace = ''.
   """
-  @spec create_nodes(context(), charlist(), integer(), integer(), (list() -> list())) ::
+  @spec create_nodes(Nifs.rcl_context(), charlist(), integer(), integer(), (list() -> list())) ::
           {:ok, [node_identifier :: charlist()]} | :error
   def create_nodes(context, node_name, num_node, queue_length \\ 1, change_order \\ & &1) do
     create_nodes_with_namespace(context, node_name, '', num_node, queue_length, change_order)
@@ -85,7 +83,7 @@ defmodule Rclex.ResourceServer do
   Create specified name multiple Nodes with specified node namespace.
   """
   @spec create_nodes_with_namespace(
-          context(),
+          Nifs.rcl_context(),
           charlist(),
           charlist(),
           integer(),
@@ -299,6 +297,7 @@ defmodule Rclex.ResourceServer do
     {:noreply, state}
   end
 
+  @spec get_identifier_name(charlist(), charlist()) :: charlist()
   defp get_identifier_name(node_name, _node_namespace = '') do
     node_name
   end
@@ -307,8 +306,14 @@ defmodule Rclex.ResourceServer do
     node_namespace ++ '/' ++ node_name
   end
 
-  @spec get_initialized_node(context(), charlist(), charlist(), reference(), reference()) ::
-          node :: reference()
+  @spec get_initialized_node(
+          Nifs.rcl_context(),
+          charlist(),
+          charlist(),
+          Nifs.rcl_node(),
+          Nifs.rcl_node_options()
+        ) ::
+          node :: Nifs.rcl_node()
   defp get_initialized_node(
          context,
          node_name,

--- a/lib/rclex/sub_loop.ex
+++ b/lib/rclex/sub_loop.ex
@@ -109,6 +109,7 @@ defmodule Rclex.SubLoop do
 
     receive do
       :stop ->
+        # FIXME: 1st arg type breaks the contract
         Process.send("#{node_identifier}/#{topic_name}/sub", :terminate, [:noconnect])
         {:stop, :normal, {node_identifier, msg_type, topic_name, wait_set, sub, call_back}}
     after

--- a/lib/rclex/sub_loop.ex
+++ b/lib/rclex/sub_loop.ex
@@ -8,6 +8,10 @@ defmodule Rclex.SubLoop do
   Implements subscribing logic.
   """
 
+  @spec start_link(
+          {charlist(), charlist(), charlist(), Nifs.rcl_subscription(), Nifs.rcl_context(),
+           function()}
+        ) :: GenServer.on_start()
   def start_link({node_identifier, msg_type, topic_name, sub, context, call_back}) do
     GenServer.start_link(
       __MODULE__,
@@ -17,6 +21,12 @@ defmodule Rclex.SubLoop do
 
   # TODO: define State struct for GerServer state which shows state explicitly.
   @impl GenServer
+  @spec init(
+          {charlist(), charlist(), charlist(), Nifs.rcl_subscription(), Nifs.rcl_context(),
+           function()}
+        ) ::
+          {:ok,
+           {charlist(), charlist(), charlist(), reference(), Nifs.rcl_subscription(), function()}}
   def init({node_identifier, msg_type, topic_name, sub, context, call_back}) do
     wait_set =
       Nifs.rcl_get_zero_initialized_wait_set()
@@ -36,6 +46,7 @@ defmodule Rclex.SubLoop do
   end
 
   # TODO: 用途の記載が必要、どのようなケースで使用するのか
+  @spec start_sub([pid()]) :: list()
   def start_sub(id_list) do
     id_list
     |> Enum.map(fn pid -> GenServer.cast(pid, {:loop}) end)
@@ -46,7 +57,7 @@ defmodule Rclex.SubLoop do
       購読が正常に行われれば，引数に受け取っていたコールバック関数を実行
   """
   @spec each_subscribe(
-          sub :: reference(),
+          sub :: Nifs.rcl_subscription(),
           node_identifier :: charlist(),
           msg_type :: charlist(),
           topic_name :: charlist()

--- a/lib/rclex/subscriber.ex
+++ b/lib/rclex/subscriber.ex
@@ -42,7 +42,9 @@ defmodule Rclex.Subscriber do
   @type id_tuple() :: {node_identifier :: charlist(), topic_name :: charlist(), :sub}
 
   @doc false
-  @spec start_link({sub :: reference(), msg_type :: charlist(), process_name :: String.t()}) ::
+  @spec start_link(
+          {sub :: Nifs.rcl_subscription(), msg_type :: charlist(), process_name :: String.t()}
+        ) ::
           GenServer.on_start()
   def start_link({sub, msg_type, process_name}) do
     Logger.debug("#{process_name} subscriber process start")
@@ -54,12 +56,12 @@ defmodule Rclex.Subscriber do
   @doc """
     subscriberを状態として持つ。start_subscribingをした際にcontextとcall_backを追加で状態として持つ。
   """
-  @spec init({sub :: reference(), msg_type :: charlist()}) :: {:ok, state :: map()}
+  @spec init({sub :: Nifs.rcl_subscription(), msg_type :: charlist()}) :: {:ok, state :: map()}
   def init({sub, msg_type}) do
     {:ok, %{subscriber: sub, msgtype: msg_type}}
   end
 
-  @spec start_subscribing(id_tuple(), Rclex.rcl_context(), call_back :: function()) :: :ok
+  @spec start_subscribing(id_tuple(), Nifs.rcl_context(), call_back :: function()) :: :ok
   def start_subscribing({node_identifier, topic_name, :sub}, context, call_back) do
     sub_identifier = "#{node_identifier}/#{topic_name}/sub"
 
@@ -69,7 +71,7 @@ defmodule Rclex.Subscriber do
     )
   end
 
-  @spec start_subscribing([id_tuple()], Rclex.rcl_context(), call_back :: function()) :: list()
+  @spec start_subscribing([id_tuple()], Nifs.rcl_context(), call_back :: function()) :: list()
   def start_subscribing(sub_list, context, call_back) do
     Enum.map(sub_list, fn {node_identifier, topic_name, :sub} ->
       sub_identifier = "#{node_identifier}/#{topic_name}/sub"

--- a/lib/rclex/timer.ex
+++ b/lib/rclex/timer.ex
@@ -36,6 +36,9 @@ defmodule Rclex.Timer do
   """
 
   @doc false
+  @spec start_link(
+          {function(), any(), integer(), charlist(), integer(), {integer(), (list() -> list())}}
+        ) :: GenServer.on_start()
   def start_link({callback, args, time, timer_name, limit, executor_settings}) do
     GenServer.start_link(
       __MODULE__,
@@ -65,7 +68,7 @@ defmodule Rclex.Timer do
           timer_name :: charlist(),
           limit :: integer,
           {queue_length :: integer(), change_order :: (list() -> list())}
-        }) :: {:ok, state :: tuple()}
+        }) :: {:ok, tuple()}
   def init({callback, args, time, timer_name, limit, {queue_length, change_order}}) do
     job_children = [
       {Rclex.JobQueue, {timer_name, queue_length}},

--- a/lib/rclex/timer_loop.ex
+++ b/lib/rclex/timer_loop.ex
@@ -5,13 +5,15 @@ defmodule Rclex.TimerLoop do
   @moduledoc """
   Pushes timer jobs to `Rclex.JobQueue`.
   """
-
+  @spec start_link({String.t(), integer(), integer()}) :: GenServer.on_start()
   def start_link({timer_name, time, limit}) do
     GenServer.start_link(__MODULE__, {timer_name, time, limit})
   end
 
   # TODO: define State struct for GerServer state which shows state explicitly.
   @impl GenServer
+  @spec init({String.t(), integer(), integer()}) ::
+          {:ok, {String.t(), integer(), integer(), integer()}}
   def init({timer_name, time, limit}) do
     GenServer.cast(self(), :loop)
     {:ok, {timer_name, time, _count = 0, limit}}

--- a/test/rclex/resource_server_test.exs
+++ b/test/rclex/resource_server_test.exs
@@ -2,12 +2,14 @@ defmodule Rclex.ResourceServerTest do
   use ExUnit.Case
   @moduletag capture_log: true
 
+  import Rclex.TestUtils, only: [get_initialized_context: 0]
+
   alias Rclex.ResourceServer
 
   setup do
     pid = start_supervised!(Rclex.ResourceServer)
 
-    context = Rclex.get_initialized_context()
+    context = get_initialized_context()
     on_exit(fn -> Rclex.Nifs.rcl_shutdown(context) end)
 
     %{context: context, pid: pid}

--- a/test/rclex_test.exs
+++ b/test/rclex_test.exs
@@ -15,13 +15,6 @@ defmodule RclexTest do
     end
   end
 
-  describe "get_initialized_context/0" do
-    test "return reference" do
-      context = Rclex.get_initialized_context()
-      assert is_reference(context)
-    end
-  end
-
   # -----------------------node_nif.c--------------------------
   test "rcl_node_get_name" do
     context = Rclex.rclexinit()


### PR DESCRIPTION
`@spec` の記述をプロジェクト内で整合が取れるよう整理しました。

以下コマンドで整合確認をしています。
```
$ docker compose run --rm -w /root/rclex rclex_docker mix dialyzer
```
※ただし既存のバグである以下は残っています。

```
Total errors: 2, Skipped: 0, Unnecessary Skips: 0
done in 0m0.9s
lib/rclex/keep_sub.ex:40:call_to_missing
Call to missing or private function Rclex.initialize_msg/0.
________________________________________________________________________________
lib/rclex/sub_loop.ex:113:call
The function call will not succeed.

:erlang.send(<<_::8, _::size(1)>>, :terminate, [:noconnect])

breaks the contract
(dest, msg, options) :: res
when dest: dst(),
     msg: term(),
     options: [:nosuspend | :noconnect],
     res: :ok | :nosuspend | :noconnect

________________________________________________________________________________
done (warnings were emitted)
Halting VM with exit status 2

```