### PR TITLE
change the recommended env and target versions for GitHub Actions CI

### DIFF
--- a/.github/workflows/ci_allver.yml
+++ b/.github/workflows/ci_allver.yml
@@ -12,8 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #dockertags: [latest, foxy-ex1.13.1-otp24.1.7, foxy-ex1.12.3-otp24.1.5, foxy-ex1.11.4-otp23.3.4, dashing-ex1.12.3-otp24.1.5, dashing-ex1.11.4-otp23.3.4, dashing-ex1.10.4-otp23.3.4, dashing-ex1.9.4-otp22.3.4.18]
-        dockertags: [latest, foxy-ex1.13.1-otp24.1.7, foxy-ex1.12.3-otp24.1.5, foxy-ex1.11.4-otp23.3.4]
+        dockertags: [latest, foxy-ex1.14.0-otp25.0.4, foxy-ex1.13.4-otp25.0.3, foxy-ex1.12.3-otp24.1.5, foxy-ex1.11.4-otp23.3.4]
     container: rclex/rclex_docker:${{ matrix.dockertags }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Currently, we use the following environment as the main development target:
 
 - Ubuntu 20.04.2 LTS (Focal Fossa)
 - ROS 2 [Foxy Fitzroy](https://docs.ros.org/en/foxy/Releases/Release-Foxy-Fitzroy.html)
-- Elixir 1.12.3-otp-24
-- Erlang/OTP 24.1.5
+- Elixir 1.13.4-otp-25
+- Erlang/OTP 25.0.3
 
 For other environments used to check the operation of this library,
 please refer to [here](https://github.com/rclex/rclex_docker#available-versions-docker-tags).


### PR DESCRIPTION
recommended version:
- Ubuntu 20.04.2 LTS (Focal Fossa)
- ROS 2 [Foxy Fitzroy](https://docs.ros.org/en/foxy/Releases/Release-Foxy-Fitzroy.html)
- Elixir 1.13.4-otp-25
- Erlang/OTP 25.0.3