### PR TITLE
Add docker command to mix test.watch section on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ docker compose down
 `mix test.watch` is introduced to automatically run unit test `mix test` and code formatting `mix format` every time the source code was editted.
 
 ```
-mix test.watch
+$ mix test.watch
+# run on docker by following
+$ docker compose run --rm -w /root/rclex rclex_docker mix test.watch
 ```
 
 ### Confirmation of operation

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ docker compose down
 
 ```
 $ mix test.watch
-# run on docker by following
+# or, run on docker by following
 $ docker compose run --rm -w /root/rclex rclex_docker mix test.watch
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -87,7 +87,9 @@ docker compose down
 `mix test.watch` を導入しており，ソースコードの編集時毎に，単体テスト `mix test` やコード整形 `mix format` を自動実行できます．
 
 ```
-mix test.watch
+$ mix test.watch
+# docker で動作させるには
+$ docker compose run --rm -w /root/rclex rclex_docker mix test.watch
 ```
 
 ### 動作確認

--- a/README_ja.md
+++ b/README_ja.md
@@ -88,7 +88,7 @@ docker compose down
 
 ```
 $ mix test.watch
-# docker で動作させるには
+# または docker で動作させるには
 $ docker compose run --rm -w /root/rclex rclex_docker mix test.watch
 ```
 


### PR DESCRIPTION
docker を使用した `mix test.watch` の実行方法を忘れてしまうため、READMEに追記しました。