### PR TITLE
Improve mix tasks usability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ TEMPLATES = src/msg_types_nif.h src/msg_types_nif.ec lib/rclex/msg_types_nif.ex
 calling_from_make:
 	mix compile
 
-$(shell test -d "$(ROS_DIR)")
-ifeq ($(.SHELLSTATUS), 0)
+ifneq ($(wildcard $(ROS_DIR)), "")
 all: $(BUILD) $(BUILD_MSG) $(PREFIX) $(TEMPLATES) $(NIF)
 else
 all: $(TEMPLATES)

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 # ROS_DISTRO is set by setup.bash in /opt/ros/${ROS_DISTRO}/.
 ifeq ($(origin ROS_DISTRO), undefined)
-$(error ROS_DISTRO is not defined)
-else
+$(warning ROS_DISTRO is not defined, so default value `foxy` will be used.)
+ROS_DISTRO = foxy
+endif
+
 ifeq ($(MIX_TARGET), host)
 ROS_DIR ?= /opt/ros/$(ROS_DISTRO)
 else
 ROS_DIR ?= $(NERVES_APP)/rootfs_overlay/opt/ros/$(ROS_DISTRO)
-endif
 endif
 
 PREFIX = $(MIX_APP_PATH)/priv

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-define ERROR_ANNOUNCEMENT
+define ERROR_ROS_DISTRO_NOT_DEFINED
 ROS_DISTRO is not defined.
 If you installed ROS 2 on your host and use on it, do `source /opt/ros/ROS_DISTRO/setup.bash` first.
 endef
 ifeq ($(origin ROS_DISTRO), undefined)
-$(error $(ERROR_ANNOUNCEMENT))
+$(error $(ERROR_ROS_DISTRO_NOT_DEFINED))
 endif
 
 ifeq ($(MIX_TARGET), host)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 define ERROR_ROS_DISTRO_NOT_DEFINED
-ROS_DISTRO is not defined.
-If you installed ROS 2 on your host and use on it, do `source /opt/ros/ROS_DISTRO/setup.bash` first.
+Environmental varialbe `ROS_DISTRO` is not defined.
+To use Rclex on a host where ROS 2 is already installed, run `source /opt/ros/ROS_DISTRO/setup.bash` first.
+Or, if you are going to use Nerves as a target, set the target name of ROS 2 distribution, e.g., `export ROS_DISTRO=foxy`.
 endef
 ifeq ($(origin ROS_DISTRO), undefined)
 $(error $(ERROR_ROS_DISTRO_NOT_DEFINED))

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-# ROS_DISTRO is set by setup.bash in /opt/ros/${ROS_DISTRO}/.
+define ERROR_ANNOUNCEMENT
+ROS_DISTRO is not defined.
+If you installed ROS 2 on your host and use on it, do `source /opt/ros/ROS_DISTRO/setup.bash` first.
+endef
 ifeq ($(origin ROS_DISTRO), undefined)
-$(warning ROS_DISTRO is not defined, so default value `foxy` will be used.)
-ROS_DISTRO = foxy
+$(error $(ERROR_ANNOUNCEMENT))
 endif
 
 ifeq ($(MIX_TARGET), host)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ For details on ROS 2, see the official [ROS 2 documentation](https://index.ros.o
 
 ## Recommended environment
 
+### The environment where host (development) and target (operation) are the same
+
 Currently, we use the following environment as the main development target:
 
 - Ubuntu 20.04.2 LTS (Focal Fossa)
@@ -42,10 +44,16 @@ Currently, we use the following environment as the main development target:
 For other environments used to check the operation of this library,
 please refer to [here](https://github.com/rclex/rclex_docker#available-versions-docker-tags).
 
+### Docker environment
+
 The pre-built Docker images are available at [Docker Hub](https://hub.docker.com/r/rclex/rclex_docker).
 You can also try the power of Rclex with it easily. Please check ["Docker Environment"](#Docker-environment) section for details.
 
-`rclex` can be operated onto Nerves. Please refer to [b5g-ex/rclex_on_nerves](https://github.com/b5g-ex/rclex_on_nerves) for more details!
+### Nerves device (target)
+
+`rclex` can be operated onto Nerves. In this case, you do not need to prepare the ROS 2 environment on the host computer to build Nerves project (so awesome!).
+
+Please refer to [Use on Nerves](USE_ON_NERVES.md) section and [b5g-ex/rclex_on_nerves](https://github.com/b5g-ex/rclex_on_nerves) example repository for more details!
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Please refer [rclex/rclex_examples](https://github.com/rclex/rclex_examples) for
 
 ## How to use
 
-This section explains the quickstart for `rclex` onto the environment where ROS 2 and Elixir have been prepared.
+This section explains the quickstart for `rclex` onto the environment where ROS 2 and Elixir have been installed.
 
 ### Create the project
 
@@ -102,11 +102,20 @@ cd rclex_usage
 mix deps.get
 ```
 
-### Prepare message types
+### Setup the ROS 2 environment
+
+```
+source /opt/ros/foxy/setup.bash
+```
+
+## Configure ROS 2 message types you want to use
 
 Rclex provides pub/sub based topic communication using the message type defined in ROS 2. Please refer [here](https://docs.ros.org/en/foxy/Concepts/About-ROS-Interfaces.html) for more details about message types in ROS 2.
 
-Here, we show how to prepare the message type for topic communication, using the `String` type as an example. First, write the following in `config/config.exs`.
+The message types you want to use in your project can be specified in `ros2_message_types` in `config/config.exs`. 
+Multiple message types can be specified separated by comma `,`.
+
+The following `config/config.exs` example wants to use `String` type.
 
 ```elixir
 import Config
@@ -114,24 +123,19 @@ import Config
 config :rclex, ros2_message_types: ["std_msgs/msg/String"]
 ```
 
-Setup the environment for ROS 2.
-
-```
-source /opt/ros/foxy/setup.bash
-```
-
-Then, execute the following Mix task to generate required definitions and files for using message types.
+Then, execute the following Mix task to generate required definitions and files for message types.
 
 ```
 mix rclex.gen.msgs
 ```
 
-Now, you can acquire the environment for Rclex!
-You can operate [Rclex API](https://hexdocs.pm/rclex/api-reference.html) onto IEx.
+If you want to change the message types in config, do `mix rclex.gen.msgs` again.
 
-### Implementation and execution of project
+### Write Rclex code
 
-Here is the simplest example `lib/rclex_usage.ex` that will publish the string to `/chatter` topic.
+Now, you can acquire the environment for [Rclex API](https://hexdocs.pm/rclex/api-reference.html)! Of course, you can execute APIs on IEx directly.
+
+Here is the simplest implementation example `lib/rclex_usage.ex` that will publish the string to `/chatter` topic.
 
 ```elixir
 defmodule RclexUsage do
@@ -155,13 +159,17 @@ defmodule RclexUsage do
 end
 ```
 
-Copy and paste the above code to `lib/rclex_usage.ex`, and execute IEx.
+Please also check the examples for Rclex.
+- [rclex/rclex_examples](https://github.com/rclex/rclex_examples)
+
+### Build and Execute
 
 ```
+mix compile
 iex -S mix
 ```
 
-Operate the following on IEx.
+Operate the following command on IEx.
 
 ```
 iex()> RclexUsage.publish_message

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ First of all, create the Mix project as a normal Elixir project.
 
 ```
 mix new rclex_usage
+cd rclex_usage
 ```
 
 ### Install rclex
@@ -88,17 +89,18 @@ You can install this package into your project
 by adding `rclex` to your list of dependencies in `mix.exs`:
 
 ```elixir
-def deps do
-  [
-    {:rclex, "~> 0.8.0"}
-  ]
-end
+  defp deps do
+    [
+      ...
+      {:rclex, "~> 0.8.0"},
+      ...
+    ]
+  end
 ```
 
 After that, execute `mix deps.get` into the project repository.
 
 ```
-cd rclex_usage
 mix deps.get
 ```
 

--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ Rclex: Publishing: Hello World from Rclex!
 {:ok, #Reference<0.2970499651.1284374532.3555>}
 ```
 
-You can confirm the above operation by subscribing with `ros2 topic echo`.
+You can confirm the above operation by subscribing with `ros2 topic echo` from the other terminal.
 
 ```
 $ source /opt/ros/foxy/setup.bash
-$ ros2 topic echo /chatter std_msgs/msg/String 
+$ ros2 topic echo /chatter std_msgs/msg/String
 data: Hello World from Rclex!
 ---
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -58,7 +58,7 @@ ROSからの大きな違いとして，通信にDDS（Data Distribution Service�
 
 ## 使用方法
 
-ここでは，ROS 2およびElixirの動作環境が導入済みである計算機での`rclex`の使用方法を示します．
+ここでは，ROS 2およびElixirの動作環境がインストール済みである計算機での`rclex`の使用方法を示します．
 
 ### プロジェクトの作成
 
@@ -89,22 +89,24 @@ cd rclex_usage
 mix deps.get
 ```
 
+### ROS 2の環境設定
+
+```
+source /opt/ros/foxy/setup.bash
+```
+
 ### メッセージの型の設定
 
 Rclexでは，ROS 2において定義されるメッセージの型を利用して出版購読型のトピック通信を行うことができます．ROS 2におけるメッセージの型については[こちら](https://docs.ros.org/en/foxy/Concepts/About-ROS-Interfaces.html)を参照してください．
 
-ここでは`String`型を例として，トピック通信で使用したいメッセージの型を設定する方法を示します．まず，`config/config.exs` に次のように記述してください．
+プロジェクトで使用したいメッセージの型は，`config/config.exs` における `ros2_message_types` で指定します．コンマ区切り `,` で複数の型を指定することもできます．
+
+ここでは `String` 型を使用したい `config/config.exs` の例を示します．
 
 ```elixir
 import Config
 
 config :rclex, ros2_message_types: ["std_msgs/msg/String"]
-```
-
-ROS 2の環境を設定ファイルから読み込んでください．
-
-```
-source /opt/ros/foxy/setup.bash
 ```
 
 その後，次のMixタスクを実行し，メッセージの型を使用するために必要な定義とファイル群を自動生成します．
@@ -113,10 +115,10 @@ source /opt/ros/foxy/setup.bash
 mix rclex.gen.msgs
 ```
 
-これで Rclex を使用する準備が整いました！  
-IEx上で[RclexのAPI](https://hexdocs.pm/rclex/api-reference.html)を実行することができます．
+### コードの実装
 
-### プロジェクトの実装と実行
+これで Rclex を使用する準備が整いました！  
+もちろんIEx上で[RclexのAPI](https://hexdocs.pm/rclex/api-reference.html)を直接実行することもできます．
 
 ここでは，最も単純なコードを対象として，プロジェクトの実装例を示します．
 次のコード `lib/rclex_usage.ex` は，`String`型のトピック `/chatter` に対して文字列を出版する処理を示しています．
@@ -143,9 +145,13 @@ defmodule RclexUsage do
 end
 ```
 
-上記のコードを `lib/rclex_usage.ex` にコピペして，IExを立ち上げてください．
+この他の実装例は，下記も参照してください．
+- [rclex/rclex_examples](https://github.com/rclex/rclex_examples)
+
+### ビルドと実行
 
 ```
+mix compile
 iex -S mix
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -21,7 +21,9 @@ ROSからの大きな違いとして，通信にDDS（Data Distribution Service�
 
 詳しくはROS 2の[公式ドキュメント](https://index.ros.org/doc/ros2/)を参照ください．
 
-## 動作環境（開発環境）
+## 対象とする環境
+
+### ホスト（開発環境）とターゲット（実行環境）が同一の場合
 
 現在，下記の環境を主な対象として開発を進めています．
 
@@ -32,10 +34,16 @@ ROSからの大きな違いとして，通信にDDS（Data Distribution Service�
 
 動作検証の対象としている環境は[こちら](https://github.com/rclex/rclex_docker#available-versions-docker-tags)を参照してください．
 
+### Docker環境
+
 [Docker Hub](https://hub.docker.com/r/rclex/rclex_docker)にてビルド済みのDockerイメージを公開しており，これを用いてRclexを簡単に試行することもできます．
 詳細は[「Docker環境の利用」](#Docker環境の利用)のセクションを参照してください．
 
-`rclex` はNerves上での実行も可能です．詳細は[b5g-ex/rclex_on_nerves](https://github.com/b5g-ex/rclex_on_nerves)を参照してください．
+### Nervesデバイス（ターゲット）
+
+`rclex` はNerves上での実行も可能です．この場合，ホスト環境にはROS 2環境を導入する必要はありません．
+
+詳細は[Use on Nerves](USE_ON_NERVES.md)の章および[b5g-ex/rclex_on_nerves](https://github.com/b5g-ex/rclex_on_nerves)のリポジトリによる例を参照してください．
 
 ## 機能
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -177,7 +177,7 @@ Rclex: Publishing: Hello World from Rclex!
 
 ```
 $ source /opt/ros/foxy/setup.bash
-$ ros2 topic echo /chatter std_msgs/msg/String 
+$ ros2 topic echo /chatter std_msgs/msg/String
 data: Hello World from Rclex!
 ---
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -66,6 +66,7 @@ ROSからの大きな違いとして，通信にDDS（Data Distribution Service�
 
 ```
 mix new rclex_usage
+cd rclex_usage
 ```
 
 ### rclexのインストール
@@ -75,17 +76,18 @@ mix new rclex_usage
 `mix.exs` の依存関係に `rclex` を追加することで，ご自身のプロジェクトにて使用することができます．
 
 ```elixir
-def deps do
-  [
-    {:rclex, "~> 0.8.0"}
-  ]
-end
+  defp deps do
+    [
+      ...
+      {:rclex, "~> 0.8.0"},
+      ...
+    ]
+  end
 ```
 
 上記を追加後，プロジェクトのディレクトリ内で `mix deps.get` を実行してください．
 
 ```
-cd rclex_usage
 mix deps.get
 ```
 

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -1,5 +1,7 @@
 # Use on Nerves
 
+`rclex` can be operated onto Nerves. In this case, you do not need to prepare the ROS 2 environment on the host computer to build Nerves project (so awesome!).
+
 This doc shows the steps on how to use Rclex on Nerves from scratch.
 
 We have also published the Nerves project that has been prepared and includes example code at [b5g-ex/rclex_on_nerves](https://github.com/b5g-ex/rclex_on_nerves). Please also refer to this repository. 
@@ -53,27 +55,34 @@ The above command extracts the ROS 2 Docker image and copies resources required 
 
 ## Configure ROS 2 message types you want to use
 
-Add `ros2_message_types` config to config/config.exs. The following example wants to use messages of type String and Twist.
+Rclex provides pub/sub based topic communication using the message type defined in ROS 2. Please refer [here](https://docs.ros.org/en/foxy/Concepts/About-ROS-Interfaces.html) for more details about message types in ROS 2.
+
+The message types you want to use in your project can be specified in `ros2_message_types` in `config/config.exs`. 
+Multiple message types can be specified separated by comma `,`.
+
+The following `config/config.exs` example wants to use `String` type.
 
 ```elixir
-config :rclex, ros2_message_types: ["std_msgs/msg/String", "geometry_msgs/msg/Twist"]
+import Config
+
+config :rclex, ros2_message_types: ["std_msgs/msg/String"]
 ```
 
-Generate message types codes for topic communication.
+Then, execute the following Mix task to generate required definitions and files for message types.
 
 ```
 mix rclex.gen.msgs
 ```
 
+If you want to change the message types in config, do `mix rclex.gen.msgs` again.
+
 ## Write Rclex code
 
-Now you can write your ROS 2 codes with Rclex!
+Now, you can acquire the environment for [Rclex API](https://hexdocs.pm/rclex/api-reference.html)! Of course, you can execute APIs on IEx directly.
 
 Please also check the examples for Rclex.
 - [rclex/rclex_examples](https://github.com/rclex/rclex_examples)
 - [b5g-ex/rclex_on_nerves](https://github.com/b5g-ex/rclex_on_nerves)
-
-If you change the message types in config, do `mix rclex.gen.msgs` again.
 
 ## Copy erlinit.config to rootfs_overlay/etc and add LD_LIBRARY_PATH
 

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -1,0 +1,103 @@
+# Use on Nerves
+
+This doc shows the steps on how to use Rclex on Nerves from scratch.
+
+We have also published the Nerves project that has been prepared and includes example code at [b5g-ex/rclex_on_nerves](https://github.com/b5g-ex/rclex_on_nerves). Please also refer to this repository. 
+> #### Support Target {: .neutral }
+>
+> Currentry Rclex only support aarch64 for Nerves, following steps use rpi4 as an example.
+
+## Create Nerves Project
+
+```
+mix nerves.new rclex_usage_on_nerves --target rpi4
+cd rclex_usage_on_nerves
+export MIX_TARGET=rpi4
+mix deps.get
+```
+
+> #### Note {: .warning }
+>
+> If `mix deps.get` failed, you may need to create SSH key and configure config/target.exs.
+
+## Add rclex as the dependency in mix.exs
+
+Please edit mix.exs to add rclex as the dependency of your Nerves project as the following.
+
+```elixir
+  defp deps do
+    [
+      ...
+      # FIXME when merged
+      {:rclex,
+       git: "https://github.com/rclex/rclex.git", branch: "improve-mix_tasks_usability-pojiro"},
+      ...
+    ]
+  end
+```
+
+```
+mix deps.get
+```
+
+## Prepare ROS 2 resoures
+
+```
+export ROS_DISTRO=foxy
+mix rclex.prep.ros2
+```
+
+## Configure ROS 2 message types you want to use
+
+Add `ros2_message_types` config to config/config.exs. The following example wants to use messages of type String and Twist.
+
+```elixir
+config :rclex, ros2_message_types: ["std_msgs/msg/String", "geometry_msgs/msg/Twist"]
+```
+
+Generate message types codes for topic communication.
+
+```
+mix rclex.gen.msgs
+```
+
+## Write Rclex code
+
+Now you can write your ROS 2 codes with Rclex!
+
+Please also check the examples for Rclex.
+- [rclex/rclex_examples](https://github.com/rclex/rclex_examples)
+- [b5g-ex/rclex_on_nerves](https://github.com/b5g-ex/rclex_on_nerves)
+
+If you change the message types in config, do `mix rclex.gen.msgs` again.
+
+## Copy erlinit.config to rootfs_overlay/etc and add LD_LIBRARY_PATH
+
+Copy erlinit.config from `nerves_system_***`.
+
+```
+cp deps/nerves_system_rpi4/rootfs_overlay/etc/erlinit.config rootfs_overlay/etc
+```
+
+Add `-e LD_LIBRARY_PATH=/opt/ros/foxy/lib` line like following.  
+`ROS_DISTRO` is needed to be written directly, following is the case of `foxy`.
+
+```
+# Enable UTF-8 filename handling in Erlang and custom inet configuration
+-e LANG=en_US.UTF-8;LANGUAGE=en;ERL_INETRC=/etc/erl_inetrc;ERL_CRASH_DUMP=/root/crash.dump
+-e LD_LIBRARY_PATH=/opt/ros/foxy/lib
+```
+
+> #### Why add LD_LIBRARY_PATH explicitly {: .info }
+>
+> ROS 2 needs the path. If you want to know the details, please read followings
+>
+> - https://github.com/ros-tooling/cross_compile/issues/363
+> - https://github.com/ros2/rcpputils/pull/122
+
+## Create fw, and burn (or, upload)
+
+```
+mix firmware
+mix burn # or, mix upload
+```

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -22,9 +22,12 @@ mix deps.get
 >
 > If `mix deps.get` failed, you may need to create SSH key and configure config/target.exs.
 
-## Add rclex as the dependency in mix.exs
+### Install rclex
 
-Please edit mix.exs to add rclex as the dependency of your Nerves project as the following.
+`rclex` is [available in Hex](https://hex.pm/docs/publish).
+
+You can install this package into your project
+by adding `rclex` to your list of dependencies in `mix.exs`:
 
 ```elixir
   defp deps do
@@ -37,6 +40,9 @@ Please edit mix.exs to add rclex as the dependency of your Nerves project as the
     ]
   end
 ```
+
+After that, execute `mix deps.get` into the project repository.
+
 
 ```
 mix deps.get

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -42,10 +42,14 @@ mix deps.get
 
 ## Prepare ROS 2 resoures
 
+Please start Docker first since Docker is used in this step.
+
 ```
 export ROS_DISTRO=foxy
 mix rclex.prep.ros2
 ```
+
+The above command extracts the ROS 2 Docker image and copies resources required for Rclex to the Nerves file system.
 
 ## Configure ROS 2 message types you want to use
 

--- a/lib/mix/tasks/rclex/gen/msgs.ex
+++ b/lib/mix/tasks/rclex/gen/msgs.ex
@@ -27,8 +27,6 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
 
   use Mix.Task
 
-  import Rclex.MixProject, only: [default_ros_distro: 0]
-
   @ros2_elixir_type_map %{
     "bool" => "boolean",
     "byte" => "integer",
@@ -63,7 +61,11 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
   end
 
   def generate(to) do
-    ros_distro = System.get_env("ROS_DISTRO", default_ros_distro())
+    ros_distro = System.get_env("ROS_DISTRO")
+
+    if is_nil(ros_distro) do
+      Mix.raise("Please set ROS_DISTRO.")
+    end
 
     ros_directory_path =
       if Mix.target() == :host do

--- a/lib/mix/tasks/rclex/gen/msgs.ex
+++ b/lib/mix/tasks/rclex/gen/msgs.ex
@@ -52,11 +52,22 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
       OptionParser.parse(args, strict: [from: :string, clean: :boolean, show_types: :boolean])
 
     case valid_options do
-      [] -> generate(rclex_dir_path!())
-      [from: from] -> generate(from, rclex_dir_path!())
-      [clean: true] -> clean()
-      [show_types: true] -> show_types()
-      _ -> Mix.shell().info(@moduledoc)
+      [] ->
+        clean()
+        generate(rclex_dir_path!())
+
+      [from: from] ->
+        clean()
+        generate(from, rclex_dir_path!())
+
+      [clean: true] ->
+        clean()
+
+      [show_types: true] ->
+        show_types()
+
+      _ ->
+        Mix.shell().info(@moduledoc)
     end
   end
 

--- a/lib/mix/tasks/rclex/gen/msgs.ex
+++ b/lib/mix/tasks/rclex/gen/msgs.ex
@@ -3,26 +3,35 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
   @moduledoc """
   #{@shortdoc}
 
-  Before generating, we have to specify message types in config.exs.
+  Before generating, specifing message types in config.exs is needed.
 
-  ex. config :rclex, ros2_message_types: ["std_msgs/msg/String"]
+  ```
+  config :rclex, ros2_message_types: ["std_msgs/msg/String"]
+  ```
 
-  Be careful, ros2 message type is case sensitive.
+  > #### Info {: .info }
+  > Be careful, ros2 message type is case sensitive.
 
   ## How to generate
 
-    $ mix rclex.gen.msgs
+  ```
+  mix rclex.gen.msgs
+  ```
 
-    This task assumes that the environment variable ROS_DISTRO is set
-    and refers to the message types from "/opt/ros/ROS_DISTRO/share".
+  This task assumes that the environment variable `ROS_DISTRO` is set
+  and refers to the message types from `/opt/ros/[ROS_DISTRO]/share`.
 
-    We can also specify directly as follows
+  We can also specify explicitly as follows
 
-    $ mix rclex.gen.msgs --from /opt/ros/foxy/share
+  ```
+  mix rclex.gen.msgs --from /opt/ros/foxy/share
+  ```
 
   ## How to clean
 
-    $ mix rclex.gen.msgs --clean
+  ```
+  mix rclex.gen.msgs --clean
+  ```
   """
 
   use Mix.Task
@@ -47,6 +56,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
 
   @ros2_built_in_types Map.keys(@ros2_elixir_type_map)
 
+  @doc false
   def run(args) do
     {valid_options, _, _} =
       OptionParser.parse(args, strict: [from: :string, clean: :boolean, show_types: :boolean])
@@ -71,6 +81,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end
   end
 
+  @doc false
   def generate(to) do
     ros_distro = System.get_env("ROS_DISTRO")
 
@@ -92,6 +103,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     generate(Path.join(ros_directory_path, "share"), to)
   end
 
+  @doc false
   def generate(from, to) do
     types = Application.get_env(:rclex, :ros2_message_types, [])
 
@@ -133,6 +145,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     recompile!()
   end
 
+  @doc false
   def clean() do
     dir_path = rclex_dir_path!()
 
@@ -145,6 +158,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end
   end
 
+  @doc false
   def show_types() do
     types = Application.get_env(:rclex, :ros2_message_types, [])
 
@@ -155,6 +169,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     Mix.shell().info(Enum.join(types, " "))
   end
 
+  @doc false
   def generate_msg_types_ex(types) do
     statements =
       Enum.map_join(types, fn type ->
@@ -172,6 +187,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     EEx.eval_file("#{templates_dir_path()}/msg_types_nif.eex", statements: statements)
   end
 
+  @doc false
   def generate_msg_types_h(types) do
     Enum.map_join(types, fn type ->
       """
@@ -180,6 +196,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end)
   end
 
+  @doc false
   def generate_msg_types_c(types) do
     Enum.map_join(types, fn type ->
       function_name = get_function_name_from_type(type)
@@ -194,6 +211,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end)
   end
 
+  @doc false
   def generate_msg_prot(type, ros2_message_type_map) do
     EEx.eval_file("#{templates_dir_path()}/msg_prot_impl.eex",
       module_name: get_module_name_from_type(type),
@@ -205,6 +223,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     )
   end
 
+  @doc false
   def generate_msg_mod(type, ros2_message_type_map) do
     EEx.eval_file("#{templates_dir_path()}/msg_mod.eex",
       module_name: get_module_name_from_type(type),
@@ -213,6 +232,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     )
   end
 
+  @doc false
   def generate_msg_nif_c(type, ros2_message_type_map) do
     EEx.eval_file("#{templates_dir_path()}/msg_nif_c.eex",
       function_name: get_function_name_from_type(type),
@@ -224,12 +244,14 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     )
   end
 
+  @doc false
   def generate_msg_nif_h(type, _ros2_message_type_map) do
     EEx.eval_file("#{templates_dir_path()}/msg_nif_h.eex",
       function_name: get_function_name_from_type(type)
     )
   end
 
+  @doc false
   @spec get_ros2_message_type_map(String.t(), String.t(), map()) :: map()
   # credo:disable-for-next-line
   def get_ros2_message_type_map(ros2_message_type, from, acc \\ %{}) do
@@ -285,21 +307,13 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     Enum.reject(rows, fn row -> String.contains?(row, "=") end)
   end
 
-  @doc """
-  iex> #{__MODULE__}.get_module_name_from_path("std_msgs/msg/String")
-  "StdMsgs.Msg.String"
-  """
+  @doc false
   @spec get_module_name_from_path(String.t()) :: String.t()
   def get_module_name_from_path(path) do
     get_module_name_impl(String.split(path, "/"))
   end
 
-  @doc """
-  iex> #{__MODULE__}.get_module_name_from_type("std_msgs/msg/String")
-  "Rclex.StdMsgs.Msg.String"
-  iex> #{__MODULE__}.get_module_name_from_type("geometry_msgs/msg/TwistWithCovariance")
-  "Rclex.GeometryMsgs.Msg.TwistWithCovariance"
-  """
+  @doc false
   def get_module_name_from_type(type) do
     if not String.contains?(type, "/") do
       Mix.raise("""
@@ -313,39 +327,25 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     |> then(&"Rclex.#{&1}")
   end
 
-  @doc """
-  iex> #{__MODULE__}.get_function_name_from_type("std_msgs/msg/String")
-  "std_msgs_msg_string"
-  iex> #{__MODULE__}.get_function_name_from_type("geometry_msgs/msg/TwistWithCovariance")
-  "geometry_msgs_msg_twist_with_covariance"
-  """
+  @doc false
   def get_function_name_from_type(type) do
     [pkg, "msg", type] = String.split(type, "/")
     Enum.join([pkg, "msg", to_down_snake(type)], "_")
   end
 
-  @doc """
-  iex> #{__MODULE__}.get_file_name_from_type("std_msgs/msg/String")
-  "std_msgs/msg/string"
-  iex> #{__MODULE__}.get_file_name_from_type("geometry_msgs/msg/TwistWithCovariance")
-  "geometry_msgs/msg/twist_with_covariance"
-  """
+  @doc false
   def get_file_name_from_type(type) do
     [pkg, "msg", type] = String.split(type, "/")
     Enum.join([pkg, "msg", to_down_snake(type)], "/")
   end
 
-  @doc """
-  iex> #{__MODULE__}.get_struct_name_from_type("std_msgs/msg/String")
-  "std_msgs__msg__String"
-  iex> #{__MODULE__}.get_struct_name_from_type("geometry_msgs/msg/TwistWithCovariance")
-  "geometry_msgs__msg__TwistWithCovariance"
-  """
+  @doc false
   def get_struct_name_from_type(type) do
     [pkg, "msg", type] = String.split(type, "/")
     Enum.join([pkg, "_msg_", type], "_")
   end
 
+  @doc false
   def create_fields_for_nifs_setdata_arg(type, ros2_message_type_map, var \\ "data") do
     Map.get(ros2_message_type_map, type)
     |> Enum.map_join(", ", fn {type, variable} ->
@@ -360,6 +360,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end)
   end
 
+  @doc false
   def create_fields_for_nifs_readdata_return(type, ros2_message_type_map, var \\ "data") do
     Map.get(ros2_message_type_map, type)
     |> Enum.with_index()
@@ -376,6 +377,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end)
   end
 
+  @doc false
   def create_fields_for_read(type, ros2_message_type_map, var \\ "data") do
     Map.get(ros2_message_type_map, type)
     |> Enum.with_index()
@@ -394,6 +396,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end)
   end
 
+  @doc false
   def create_fields_for_defstruct(type, ros2_message_type_map) do
     Map.get(ros2_message_type_map, type)
     |> Enum.map_join(", ", fn {type, variable} ->
@@ -408,6 +411,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end)
   end
 
+  @doc false
   def create_fields_for_type(type, ros2_message_type_map) do
     Map.get(ros2_message_type_map, type)
     |> Enum.map_join(", ", fn {type, variable} ->
@@ -427,6 +431,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end)
   end
 
+  @doc false
   @spec create_readdata_statements(String.t(), map()) :: String.t()
   def create_readdata_statements(type, ros2_message_type_map) do
     type_var_list = Map.get(ros2_message_type_map, type)
@@ -440,6 +445,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     "enif_make_tuple(env,#{Enum.count(type_var_list)},\n  #{statements})"
   end
 
+  @doc false
   # credo:disable-for-next-line
   def create_readdata_statements_impl(type, ros2_message_type_map, var)
       when type in @ros2_built_in_types and is_map(ros2_message_type_map) do
@@ -470,6 +476,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end
   end
 
+  @doc false
   def create_readdata_statements_impl(type, ros2_message_type_map, var)
       when is_map(ros2_message_type_map) do
     if is_ros2_list(type) do
@@ -479,6 +486,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end
   end
 
+  @doc false
   def create_readdata_statements_impl_for_list(type, ros2_message_type_map, var)
       when is_map(ros2_message_type_map) do
     [_, list_type, list_length] = Regex.run(~r/^(.+)\[([0-9]+)\]$/, type)
@@ -493,6 +501,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     "enif_make_list(env,#{list_length},\n  #{statements})"
   end
 
+  @doc false
   def create_readdata_statements_impl_for_tuple(type, ros2_message_type_map, var)
       when is_map(ros2_message_type_map) do
     type_var_list = Map.get(ros2_message_type_map, type)
@@ -505,6 +514,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     "enif_make_tuple(env,#{Enum.count(type_var_list)},\n  #{statements})"
   end
 
+  @doc false
   def create_setdata_statements(type, ros2_message_type_map) do
     type_var_list = Map.get(ros2_message_type_map, type)
 
@@ -533,6 +543,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     """ <> "#{statements}"
   end
 
+  @doc false
   # credo:disable-for-next-line
   def create_setdata_statements_impl(type, ros2_message_type_map, var_res, var_term, var_local)
       when type in @ros2_built_in_types and is_map(ros2_message_type_map) do
@@ -622,6 +633,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end
   end
 
+  @doc false
   def create_setdata_statements_impl(type, ros2_message_type_map, var, var_term, var_local) do
     if is_ros2_list(type) do
       create_setdata_statements_impl_for_list(
@@ -642,6 +654,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     end
   end
 
+  @doc false
   def create_setdata_statements_impl_for_list(
         type,
         ros2_message_type_map,
@@ -681,6 +694,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     """ <> "#{statements}"
   end
 
+  @doc false
   def create_setdata_statements_impl_for_tuple(
         type,
         ros2_message_type_map,
@@ -716,31 +730,18 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     """ <> "#{statements}"
   end
 
-  @doc """
-  iex> #{__MODULE__}.get_module_name_impl(["std_msgs", "msg", "String"])
-  "StdMsgs.Msg.String"
-  iex> #{__MODULE__}.get_module_name_impl(["geometry_msgs", "msg", "TwistWithCovariance"])
-  "GeometryMsgs.Msg.TwistWithCovariance"
-  """
+  @doc false
   def get_module_name_impl([pkg, msg = "msg", type]) do
     Enum.join([convert_package_name_to_capitalized(pkg), String.capitalize(msg), type], ".")
   end
 
-  @doc """
-  iex> #{__MODULE__}.convert_package_name_to_capitalized("std_msgs")
-  "StdMsgs"
-  """
+  @doc false
   def convert_package_name_to_capitalized(binary) do
     String.split(binary, "_")
     |> Enum.map_join(&String.capitalize(&1))
   end
 
-  @doc """
-  iex> #{__MODULE__}.to_down_snake("Vector3")
-  "vector3"
-  iex> #{__MODULE__}.to_down_snake("TwistWithCovariance")
-  "twist_with_covariance"
-  """
+  @doc false
   def to_down_snake(type_name) do
     String.split(type_name, ~r/[A-Z][a-z0-9]+/, include_captures: true, trim: true)
     |> Enum.map_join("_", &String.downcase(&1))

--- a/lib/mix/tasks/rclex/gen/msgs.ex
+++ b/lib/mix/tasks/rclex/gen/msgs.ex
@@ -69,7 +69,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
 
     ros_directory_path =
       if Mix.target() == :host do
-        System.get_env("ROS_DIR", "/opt/ros/#{ros_distro}")
+        "/opt/ros/#{ros_distro}"
       else
         Path.join(File.cwd!(), "rootfs_overlay/opt/ros/#{ros_distro}")
       end

--- a/lib/mix/tasks/rclex/prep/ros2.ex
+++ b/lib/mix/tasks/rclex/prep/ros2.ex
@@ -169,10 +169,10 @@ defmodule Mix.Tasks.Rclex.Prep.Ros2 do
   end
 
   defp copy_dest_dir_path(path \\ File.cwd!(), arch, ros_distro) do
-    if File.exists?(Path.join(path, "rootfs_overlay")) do
-      Path.join(path, "rootfs_overlay")
-    else
+    if Mix.target() == :host do
       Path.join(path, ".ros2/resources/from-docker/#{arch}/#{ros_distro}")
+    else
+      Path.join(path, "rootfs_overlay")
     end
   end
 end

--- a/lib/mix/tasks/rclex/prep/ros2.ex
+++ b/lib/mix/tasks/rclex/prep/ros2.ex
@@ -13,8 +13,16 @@ defmodule Mix.Tasks.Rclex.Prep.Ros2 do
 
   ## Examples
 
+  specify arch explicitly with `--arch` option
+
   ```
   mix rclex.prep.ros2 --arch arm64v8
+  ```
+
+  For Nerves, `export MIX_TARGET=[TARGET]` is invoked properly, `--arch` option is not needed.
+
+  ```
+  mix rclex.prep.ros2
   ```
   """
 

--- a/lib/mix/tasks/rclex/prep/ros2.ex
+++ b/lib/mix/tasks/rclex/prep/ros2.ex
@@ -20,8 +20,6 @@ defmodule Mix.Tasks.Rclex.Prep.Ros2 do
 
   use Mix.Task
 
-  import Rclex.MixProject, only: [default_ros_distro: 0]
-
   @arm64v8_ros_distros ["foxy", "galactic", "humble"]
   @amd64_ros_distros ["foxy", "galactic", "humble"]
   @supported_arch ["arm64v8", "amd64"]
@@ -55,7 +53,7 @@ defmodule Mix.Tasks.Rclex.Prep.Ros2 do
       """)
     end
 
-    ros_distro = System.get_env("ROS_DISTRO", default_ros_distro())
+    ros_distro = System.get_env("ROS_DISTRO")
     supported_ros_distros = Map.get(@supported_ros_distros, arch, [])
 
     if ros_distro not in supported_ros_distros do

--- a/lib/mix/tasks/rclex/prep/ros2.ex
+++ b/lib/mix/tasks/rclex/prep/ros2.ex
@@ -118,7 +118,7 @@ defmodule Mix.Tasks.Rclex.Prep.Ros2 do
   defp copy_vendor_resources_from_docker!(dest_dir_path, arch, ros_distro) do
     dir_name = arch_dir_name(arch)
 
-    dest_path = Path.join(dest_dir_path, "/lib/#{dir_name}")
+    dest_path = Path.join(dest_dir_path, "/opt/ros/#{ros_distro}/lib")
     File.mkdir_p!(dest_path)
 
     [

--- a/mix.exs
+++ b/mix.exs
@@ -24,12 +24,6 @@ defmodule Rclex.MixProject do
       compilers: [:elixir_make] ++ Mix.compilers(),
       make_targets: ["all"],
       make_clean: ["clean"],
-      make_error_message: """
-      If the error message above says that rcl/rcl.h can't be found,
-      then the fix is to setup the ROS 2 environment. If you have
-      already installed ROS 2 environment, run the following command.
-      `. /opt/ros/${ROS_DISTRO}/setup.bash`
-      """,
       aliases: [format: [&format_c/1, "format"]],
       dialyzer: dialyzer()
     ]
@@ -80,7 +74,7 @@ defmodule Rclex.MixProject do
 
   defp docs do
     [
-      extras: ["README.md", "README_ja.md", "CHANGELOG.md"],
+      extras: ["README.md", "README_ja.md", "USE_ON_NERVES.md", "CHANGELOG.md"],
       main: "readme",
       source_ref: "v#{@version}",
       source_url: @source_url

--- a/mix.exs
+++ b/mix.exs
@@ -7,12 +7,6 @@ defmodule Rclex.MixProject do
 
   @version "0.8.0"
   @source_url "https://github.com/rclex/rclex"
-  @default_ros_distro Regex.run(
-                        ~r/ROS_DISTRO\s*=\s*([[:alpha:]]+)/,
-                        File.read!("Makefile"),
-                        capture: :all_but_first
-                      )
-                      |> List.first()
 
   def project do
     [
@@ -40,8 +34,6 @@ defmodule Rclex.MixProject do
       dialyzer: dialyzer()
     ]
   end
-
-  def default_ros_distro(), do: @default_ros_distro
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,12 @@ defmodule Rclex.MixProject do
 
   @version "0.8.0"
   @source_url "https://github.com/rclex/rclex"
+  @default_ros_distro Regex.run(
+                        ~r/ROS_DISTRO\s*=\s*([[:alpha:]]+)/,
+                        File.read!("Makefile"),
+                        capture: :all_but_first
+                      )
+                      |> List.first()
 
   def project do
     [
@@ -34,6 +40,8 @@ defmodule Rclex.MixProject do
       dialyzer: dialyzer()
     ]
   end
+
+  def default_ros_distro(), do: @default_ros_distro
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/test/mix/tasks/rclex/gen/msgs_test.exs
+++ b/test/mix/tasks/rclex/gen/msgs_test.exs
@@ -1,8 +1,6 @@
 defmodule Mix.Tasks.Rclex.Gen.MsgsTest do
   use ExUnit.Case
 
-  doctest Mix.Tasks.Rclex.Gen.Msgs
-
   alias Mix.Tasks.Rclex.Gen.Msgs, as: GenMsgs
 
   @ros2_message_type_map %{
@@ -253,6 +251,86 @@ defmodule Mix.Tasks.Rclex.Gen.MsgsTest do
         )
 
       assert expected == GenMsgs.create_setdata_statements(type, @ros2_message_type_map)
+    end
+  end
+
+  test "get_module_name_from_path/1" do
+    assert "StdMsgs.Msg.String" == GenMsgs.get_module_name_from_path("std_msgs/msg/String")
+  end
+
+  for {expected, type} <- [
+        {"Rclex.StdMsgs.Msg.String", "std_msgs/msg/String"},
+        {"Rclex.GeometryMsgs.Msg.TwistWithCovariance", "geometry_msgs/msg/TwistWithCovariance"}
+      ] do
+    test "get_module_name_from_type/1, type: #{type}" do
+      expected = unquote(expected)
+      type = unquote(type)
+
+      assert expected == GenMsgs.get_module_name_from_type(type)
+    end
+  end
+
+  for {expected, type} <- [
+        {"std_msgs_msg_string", "std_msgs/msg/String"},
+        {"geometry_msgs_msg_twist_with_covariance", "geometry_msgs/msg/TwistWithCovariance"}
+      ] do
+    test "get_function_name_from_type/1, type: #{type}" do
+      expected = unquote(expected)
+      type = unquote(type)
+
+      assert expected == GenMsgs.get_function_name_from_type(type)
+    end
+  end
+
+  for {expected, type} <- [
+        {"std_msgs/msg/string", "std_msgs/msg/String"},
+        {"geometry_msgs/msg/twist_with_covariance", "geometry_msgs/msg/TwistWithCovariance"}
+      ] do
+    test "get_file_name_from_type/1, type: #{type}" do
+      expected = unquote(expected)
+      type = unquote(type)
+
+      assert expected == GenMsgs.get_file_name_from_type(type)
+    end
+  end
+
+  for {expected, type} <- [
+        {"std_msgs__msg__String", "std_msgs/msg/String"},
+        {"geometry_msgs__msg__TwistWithCovariance", "geometry_msgs/msg/TwistWithCovariance"}
+      ] do
+    test "get_struct_name_from_type/1, type: #{type}" do
+      expected = unquote(expected)
+      type = unquote(type)
+
+      assert expected == GenMsgs.get_struct_name_from_type(type)
+    end
+  end
+
+  for {expected, list} <- [
+        {"StdMsgs.Msg.String", ["std_msgs", "msg", "String"]},
+        {"GeometryMsgs.Msg.TwistWithCovariance", ["geometry_msgs", "msg", "TwistWithCovariance"]}
+      ] do
+    test "get_module_name_impl/1, list: #{inspect(list)}" do
+      expected = unquote(expected)
+      list = unquote(list)
+
+      assert expected == GenMsgs.get_module_name_impl(list)
+    end
+  end
+
+  test "convert_package_name_to_capitalized/1" do
+    assert "StdMsgs" == GenMsgs.convert_package_name_to_capitalized("std_msgs")
+  end
+
+  for {expected, type} <- [
+        {"vector3", "Vector3"},
+        {"twist_with_covariance", "TwistWithCovariance"}
+      ] do
+    test "to_down_snake/1, type: #{type}" do
+      expected = unquote(expected)
+      type = unquote(type)
+
+      assert expected == GenMsgs.to_down_snake(type)
     end
   end
 end

--- a/test/mix/tasks/rclex/prep/ros2_test.exs
+++ b/test/mix/tasks/rclex/prep/ros2_test.exs
@@ -8,48 +8,29 @@ defmodule Mix.Tasks.Rclex.Prep.Ros2Test do
 
   @tag skip: "take time"
   @tag :tmp_dir
-  test "copy_ros2_resources_from_docker!/3", %{tmp_dir: tmp_dir_path} do
-    Mix.Tasks.Rclex.Prep.Ros2.copy_ros2_resources_from_docker!(tmp_dir_path, "arm64v8", "foxy")
+  test "copy_from_docker!/2", %{tmp_dir: tmp_dir_path} do
+    Mix.Tasks.Rclex.Prep.Ros2.copy_from_docker!(tmp_dir_path, "arm64v8", "foxy")
 
+    assert File.exists?(Path.join(tmp_dir_path, ".gitignore"))
     assert File.ls!(tmp_dir_path) |> Enum.count() > 0
   end
 
-  @tag skip: "take time"
-  @tag :tmp_dir
-  test "copy_vendor_resources_from_docker!/3", %{tmp_dir: tmp_dir_path} do
-    Mix.Tasks.Rclex.Prep.Ros2.copy_vendor_resources_from_docker!(tmp_dir_path, "arm64v8", "foxy")
-
-    assert File.ls!(tmp_dir_path) |> Enum.count() > 0
-  end
-
-  test "ros2_docker_image_tag/2" do
+  test "ros_docker_image_tag/2" do
     assert "arm64v8/ros:foxy-ros-core" =
-             Mix.Tasks.Rclex.Prep.Ros2.ros2_docker_image_tag("arm64v8", "foxy")
+             Mix.Tasks.Rclex.Prep.Ros2.ros_docker_image_tag("arm64v8", "foxy")
+
+    assert "amd64/ros:humble-ros-core" =
+             Mix.Tasks.Rclex.Prep.Ros2.ros_docker_image_tag("amd64", "humble")
   end
 
   test "parse_args/1" do
-    assert [arch: "arm64v8", ros2_distro: "foxy"] =
-             Mix.Tasks.Rclex.Prep.Ros2.parse_args(["--arch", "arm64v8", "--ros2-distro", "foxy"])
-
-    assert [nerves_system: "rpi4", ros2_distro: "foxy"] =
-             Mix.Tasks.Rclex.Prep.Ros2.parse_args([
-               "--nerves-system",
-               "rpi4",
-               "--ros2-distro",
-               "foxy"
-             ])
+    assert [arch: "arm64v8"] = Mix.Tasks.Rclex.Prep.Ros2.parse_args(["--arch", "arm64v8"])
+    assert [] = Mix.Tasks.Rclex.Prep.Ros2.parse_args([])
   end
 
   @tag :tmp_dir
-  test "create_resources_directory!/2", %{tmp_dir: tmp_dir_path} do
-    arch = "arm64v8"
-    ros2_distro = "foxy"
-
-    directory_path = Path.join(tmp_dir_path, ".ros2/resources/from-docker/#{arch}/#{ros2_distro}")
-
-    ^directory_path =
-      Mix.Tasks.Rclex.Prep.Ros2.create_resources_directory!(tmp_dir_path, arch, ros2_distro)
-
-    assert File.exists?(directory_path)
+  test "create_resources_directory!/1", %{tmp_dir: tmp_dir_path} do
+    :ok = Mix.Tasks.Rclex.Prep.Ros2.create_resources_directory!(tmp_dir_path)
+    assert File.exists?(Path.join(tmp_dir_path, ".gitignore"))
   end
 end


### PR DESCRIPTION
PR #195 のMakefile の改良によって、ユーザは `ROS_DIR` を意識する必要がなくなり、以下のいずれかを実行するだけでよいとする方針となりました。

* ホストでの利用時
  * `source /opt/ros/foxy/setup.bash`
* Nerves での利用時
  * `export ROS_DISTRO=foxy`

上記の方針に合わせ、 `mix rclex.gen.msgs`, `,mix rclex.prep.ros2` を改良しました。

### mix rclex.gen.msgs の改良点

Nerves 向けに利用する際に、コード生成で参照するディレクトリを`--from オプション`で指定する必要をなくしました。

### mix rclex.prep.ros2 の改良点

タスク実行前に `ROS_DISTRO` が export されていることが保証されるため、`--ros2-distro foxy` オプションが不要となりました。

また、Nerves 向けに利用する際には、rootfs_overlay ディレクトリに直接リソースをコピーするようにしました。

※リファクタ含めコードをそれなりに変更しているため、変更差異でのレビューは非推奨です。
　変更後コードでレビューいただければと思います。


以上です。