### PR TITLE
release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # CHANGELOG
 
+## v0.8.1 on 03 Dec 2022
+
+**Full Changelog**: https://github.com/rclex/rclex/compare/v0.8.0...v0.8.1
+
+* New features:
+  * Create docs for Use on Nerves and improve related mix tasks by @pojiro in https://github.com/rclex/rclex/pull/198
+* Code Improvements/Fixes:
+  * Change `raise` to `Mix.raise` to proper mix task error handling by @pojiro in https://github.com/rclex/rclex/pull/194
+  * Change Makefile's if statement to confirm ROS_DIR exists by @pojiro in https://github.com/rclex/rclex/pull/195
+  * Improve mix tasks usability by @pojiro in https://github.com/rclex/rclex/pull/196
+* Bumps:
+  * Bump ex_doc from 0.29.0 to 0.29.1 by @dependabot in https://github.com/rclex/rclex/pull/199
+  * Bump elixir_make from 0.6.3 to 0.7.0 by @dependabot in https://github.com/rclex/rclex/pull/200
+* Known issues to be addressed in the near future:
+  * Lock `git_hooks` to 0.6.5 due to its issue in https://github.com/rclex/rclex/issues/138
+  * Bump to Humble Hawksbill in https://github.com/rclex/rclex/issues/114
+  * Release rcl nif resources when GerServer terminates in https://github.com/rclex/rclex/issues/160
+* Note in this release: none
+
 ## v0.8.0 on 01 Nov 2022
 
 **Full Changelog**: https://github.com/rclex/rclex/compare/v0.7.2...v0.8.0

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
   defp deps do
     [
       ...
-      {:rclex, "~> 0.8.0"},
+      {:rclex, "~> 0.8.1"},
       ...
     ]
   end

--- a/README_ja.md
+++ b/README_ja.md
@@ -79,7 +79,7 @@ cd rclex_usage
   defp deps do
     [
       ...
-      {:rclex, "~> 0.8.0"},
+      {:rclex, "~> 0.8.1"},
       ...
     ]
   end

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -34,8 +34,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
     [
       ...
       # FIXME when merged
-      {:rclex,
-       git: "https://github.com/rclex/rclex.git", branch: "improve-mix_tasks_usability-pojiro"},
+      {:rclex, "~> 0.8.1"},
       ...
     ]
   end


### PR DESCRIPTION
## v0.8.1 on 03 Dec 2022

**Full Changelog**: https://github.com/rclex/rclex/compare/v0.8.0...v0.8.1

* New features:
  * Create docs for Use on Nerves and improve related mix tasks by @pojiro in https://github.com/rclex/rclex/pull/198
* Code Improvements/Fixes:
  * Change `raise` to `Mix.raise` to proper mix task error handling by @pojiro in https://github.com/rclex/rclex/pull/194
  * Change Makefile's if statement to confirm ROS_DIR exists by @pojiro in https://github.com/rclex/rclex/pull/195
  * Improve mix tasks usability by @pojiro in https://github.com/rclex/rclex/pull/196
* Bumps:
  * Bump ex_doc from 0.29.0 to 0.29.1 by @dependabot in https://github.com/rclex/rclex/pull/199
  * Bump elixir_make from 0.6.3 to 0.7.0 by @dependabot in https://github.com/rclex/rclex/pull/200
* Known issues to be addressed in the near future:
  * Lock `git_hooks` to 0.6.5 due to its issue in https://github.com/rclex/rclex/issues/138
  * Bump to Humble Hawksbill in https://github.com/rclex/rclex/issues/114
  * Release rcl nif resources when GerServer terminates in https://github.com/rclex/rclex/issues/160
* Note in this release: none