### PR TITLE
release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## v0.8.2 on 03 Dec 2022
+
+**Full Changelog**: https://github.com/rclex/rclex/compare/v0.8.1...v0.8.2
+
+* New features: none
+* Code Improvements/Fixes:
+  * fix to check ROS_DIR by @takasehideki in https://github.com/rclex/rclex/pull/206
+* Bumps: none
+* Known issues to be addressed in the near future:
+  * Lock `git_hooks` to 0.6.5 due to its issue in https://github.com/rclex/rclex/issues/138
+  * Bump to Humble Hawksbill in https://github.com/rclex/rclex/issues/114
+  * Release rcl nif resources when GerServer terminates in https://github.com/rclex/rclex/issues/160
+* Note in this release:
+  * This release only fixes a critical issue that existed in the previous release,,,
+
 ## v0.8.1 on 03 Dec 2022
 
 **Full Changelog**: https://github.com/rclex/rclex/compare/v0.8.0...v0.8.1

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
   defp deps do
     [
       ...
-      {:rclex, "~> 0.8.1"},
+      {:rclex, "~> 0.8.2"},
       ...
     ]
   end

--- a/README_ja.md
+++ b/README_ja.md
@@ -79,7 +79,7 @@ cd rclex_usage
   defp deps do
     [
       ...
-      {:rclex, "~> 0.8.1"},
+      {:rclex, "~> 0.8.2"},
       ...
     ]
   end

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -33,7 +33,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
   defp deps do
     [
       ...
-      {:rclex, "~> 0.8.1"},
+      {:rclex, "~> 0.8.2"},
       ...
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Rclex.MixProject do
   ROS 2 Client Library for Elixir.
   """
 
-  @version "0.8.1"
+  @version "0.8.2"
   @source_url "https://github.com/rclex/rclex"
 
   def project do


### PR DESCRIPTION
## v0.8.2 on 03 Dec 2022

**Full Changelog**: https://github.com/rclex/rclex/compare/v0.8.1...v0.8.2

* New features: none
* Code Improvements/Fixes:
  * fix to check ROS_DIR by @takasehideki in https://github.com/rclex/rclex/pull/206
* Bumps: none
* Known issues to be addressed in the near future:
  * Lock `git_hooks` to 0.6.5 due to its issue in https://github.com/rclex/rclex/issues/138
  * Bump to Humble Hawksbill in https://github.com/rclex/rclex/issues/114
  * Release rcl nif resources when GerServer terminates in https://github.com/rclex/rclex/issues/160
* Note in this release:
  * This release only fixes a critical issue that existed in the previous release,,,
