### PR TITLE
Remove useless gitignore line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,11 +25,6 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 rclex-*.tar
 
-## Original ignoring files
-# for NIFs
-*.so
-*.o
-
 # for VSCode
 /.elixir_ls/
 /.vscode/


### PR DESCRIPTION
WHY: remove
リポジトリ内にできてしまったファイルは意図して無視するべきです。
例えばバグなどにより意図せず異なるパスに生成してしまったファイルを無視してしまうと、
バグに気づけなくなるという副作用があります。