### PR TITLE
Adding handling for nested Message types from different Packages

### DIFF
--- a/lib/mix/tasks/rclex/gen/msgs.ex
+++ b/lib/mix/tasks/rclex/gen/msgs.ex
@@ -255,7 +255,6 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
   @spec get_ros2_message_type_map(String.t(), String.t(), map()) :: map()
   # credo:disable-for-next-line
   def get_ros2_message_type_map(ros2_message_type, from, acc \\ %{}) do
-    [package_name, "msg", _type_name] = String.split(ros2_message_type, "/")
 
     package_name = case String.split(ros2_message_type, "/") do
       [pn, "msg", _type_name]  -> pn

--- a/lib/mix/tasks/rclex/gen/msgs.ex
+++ b/lib/mix/tasks/rclex/gen/msgs.ex
@@ -255,11 +255,8 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
   @spec get_ros2_message_type_map(String.t(), String.t(), map()) :: map()
   # credo:disable-for-next-line
   def get_ros2_message_type_map(ros2_message_type, from, acc \\ %{}) do
+    package_name = get_package_name(ros2_message_type)
 
-    package_name = case String.split(ros2_message_type, "/") do
-      [pn, "msg", _type_name]  -> pn
-      [pn, _type_name] -> pn
-    end
     rows =
       "#{Path.join(from, ros2_message_type)}.msg"
       |> File.read!()
@@ -277,16 +274,15 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
           # NOTE: currently we do not support default value
           |> Enum.take(2)
 
-        cond do
-          type in @ros2_built_in_types -> {type, variable}
-          is_ros2_built_in_list(type) -> {type, variable}
-          String.contains?(type, "/") ->
-            case String.split(type, "/") do
-              [_package_name, "msg", _t] -> {type, variable}
-              [pn, t] -> {Path.join("#{pn}/msg", t), variable}
-            end
-          true -> {Path.join("#{package_name}/msg", type), variable}
-        end
+        type =
+          cond do
+            type in @ros2_built_in_types -> type
+            is_ros2_built_in_list(type) -> type
+            String.contains?(type, "/") -> get_nested_ros2_type(type)
+            true -> Path.join("#{package_name}/msg", type)
+          end
+
+        {type, variable}
       end)
 
     type_map = Map.put(acc, ros2_message_type, type_variable_tuples)
@@ -776,6 +772,20 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
 
   defp is_ros2_list(type) when is_binary(type) do
     String.match?(type, ~r/.+\[[0-9]+\]/)
+  end
+
+  defp get_package_name(ros2_message_type) do
+    case String.split(ros2_message_type, "/") do
+      [package_name, "msg", _type_name] -> package_name
+      [package_name, _type_name] -> package_name
+    end
+  end
+
+  defp get_nested_ros2_type(type) do
+    case String.split(type, "/") do
+      [_package_name, "msg", _t] -> type
+      [package_name, t] -> Path.join("#{package_name}/msg", t)
+    end
   end
 
   defp list_type(type) do

--- a/lib/mix/tasks/rclex/gen/msgs.ex
+++ b/lib/mix/tasks/rclex/gen/msgs.ex
@@ -257,6 +257,10 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
   def get_ros2_message_type_map(ros2_message_type, from, acc \\ %{}) do
     [package_name, "msg", _type_name] = String.split(ros2_message_type, "/")
 
+    package_name = case String.split(ros2_message_type, "/") do
+      [pn, "msg", _type_name]  -> pn
+      [pn, _type_name] -> pn
+    end
     rows =
       "#{Path.join(from, ros2_message_type)}.msg"
       |> File.read!()
@@ -277,7 +281,11 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
         cond do
           type in @ros2_built_in_types -> {type, variable}
           is_ros2_built_in_list(type) -> {type, variable}
-          String.contains?(type, "/") -> {type, variable}
+          String.contains?(type, "/") ->
+            case String.split(type, "/") do
+              [_package_name, "msg", _t] -> {type, variable}
+              [pn, t] -> {Path.join("#{pn}/msg", t), variable}
+            end
           true -> {Path.join("#{package_name}/msg", type), variable}
         end
       end)


### PR DESCRIPTION
Hi,

First, I really like your project! Awesome work!

I ran into an issue, when I tried to use mix `rclex.gen.msgs` for `geometry_msgs/msg/Vector3Stamped`. The issue was, at least to my understanding, that the nested message types do not contain the `/msg/` inside the `Vector3Stamped.msg` files.

In the `geometry_msgs/msg/Twist` Messages which are used in your examples, the nested Messages do not cause this issue because since they are within the same package, they do not have the `/` in their Type.
 In the case of the `geometry_msgs/msg/Vector3Stamped` the containing messages `std_msgs/Header` and `builtin_interfaces/Time` do contain an `/`, which leads to an issue with the subsequent matches.

I made a little fix, that works for me, in which two additional case matches are built in, which checks, if there is a package name in front of the type of the nested message.
