### PR TITLE
release v0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## v0.8.5 on 05 Jun 2023
+
+**Full Changelog**: https://github.com/rclex/rclex/compare/v0.8.4...v0.8.5
+
+* New features:
+  * * Adding handling for nested Message types from different Packages by @steve-at in https://github.com/rclex/rclex/pull/230
+* Code Improvements/Fixes: none
+* Bumps:
+  * Bump elixir_make from 0.7.6 to 0.7.7
+* Known issues to be addressed in the near future:
+  * `publish/2` sometimes failed just after `create_publisher/3` in https://github.com/rclex/rclex/issues/212
+  * Lock `git_hooks` to 0.6.5 due to its issue in https://github.com/rclex/rclex/issues/138
+  * Bump to Humble Hawksbill in https://github.com/rclex/rclex/issues/114
+  * Bump to Iron Irwini in https://github.com/rclex/rclex/issues/228
+  * Release rcl nif resources when GerServer terminates in https://github.com/rclex/rclex/issues/160
+* Note in this release: none
+
 ## v0.8.4 on 11 Apr 2023
 
 **Full Changelog**: https://github.com/rclex/rclex/compare/v0.8.3...v0.8.4

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
   defp deps do
     [
       ...
-      {:rclex, "~> 0.8.4"},
+      {:rclex, "~> 0.8.5"},
       ...
     ]
   end

--- a/README_ja.md
+++ b/README_ja.md
@@ -79,7 +79,7 @@ cd rclex_usage
   defp deps do
     [
       ...
-      {:rclex, "~> 0.8.4"},
+      {:rclex, "~> 0.8.5"},
       ...
     ]
   end

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -58,7 +58,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
   defp deps do
     [
       ...
-      {:rclex, "~> 0.8.4"},
+      {:rclex, "~> 0.8.5"},
       ...
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Rclex.MixProject do
   ROS 2 Client Library for Elixir.
   """
 
-  @version "0.8.4"
+  @version "0.8.5"
   @source_url "https://github.com/rclex/rclex"
 
   def project do


### PR DESCRIPTION
**Full Changelog**: https://github.com/rclex/rclex/compare/v0.8.4...v0.8.5

* New features:
  * * Adding handling for nested Message types from different Packages by @steve-at in https://github.com/rclex/rclex/pull/230
* Code Improvements/Fixes: none
* Bumps:
  * Bump elixir_make from 0.7.6 to 0.7.7
* Known issues to be addressed in the near future:
  * `publish/2` sometimes failed just after `create_publisher/3` in https://github.com/rclex/rclex/issues/212
  * Lock `git_hooks` to 0.6.5 due to its issue in https://github.com/rclex/rclex/issues/138
  * Bump to Humble Hawksbill in https://github.com/rclex/rclex/issues/114
  * Bump to Iron Irwini in https://github.com/rclex/rclex/issues/228
  * Release rcl nif resources when GerServer terminates in https://github.com/rclex/rclex/issues/160
* Note in this release: none