### PR TITLE
Fix bug of `mix rclex.gen.msgs`

### DIFF
--- a/lib/mix/tasks/rclex/gen/msgs.ex
+++ b/lib/mix/tasks/rclex/gen/msgs.ex
@@ -554,7 +554,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
       "bool" ->
         """
         unsigned #{var_local};
-        if(!enif_get_atom_length(env,#{var_term}},&#{var_local},ERL_NIF_LATIN1)) {
+        if(!enif_get_atom_length(env,#{var_term},&#{var_local},ERL_NIF_LATIN1)) {
           return enif_make_badarg(env);
         }
         if(#{var_local} == 4) res->#{var_res} = true;


### PR DESCRIPTION
bool 型 msg の C コード生成に不要な中括弧があったのを削除

https://github.com/rt-net/raspimouse2/blob/master/raspimouse_msgs/msg/Leds.msg から生成する際に見つけました

修正により動作することも確認済です