### PR TITLE
Add humble support to arm32v7_ros_distros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR)
 
 # for ROS libs
 ifeq ($(ROS_DISTRO), humble)
-ROS_CFLAGS  ?= -I$(ROS_DIR)/include $(addprefix -I,$(sort $(dir $(wildcard $(ROS_DIR)/include/*/))))
+ROS_INCS    ?= rcl rcl_yaml_param_parser rcutils rmw rosidl_runtime_c rosidl_typesupport_interface
+ROS_CFLAGS  ?= $(addprefix -I$(ROS_DIR)/include/, $(ROS_INCS)) $(addprefix -I, $(wildcard $(ROS_DIR)/include/*_msgs))
 else
 ROS_CFLAGS  ?= -I$(ROS_DIR)/include
 endif

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -18,6 +18,15 @@ Currently, we have confirmed the following boards as the Nerves device that can 
 | [ODYSSEY - STM32MP157C](https://github.com/b5g-ex/nerves_system_stm32mp157c_odyssey) | stm32mp157c_odyssey | arm32v7 | Third-party supported |
 | [F3RP70 (e-RT3 Plus)](https://github.com/pojiro/nerves_system_f3rp70) | f3rp70 | arm32v7 | Third-party supported |
 
+The below is the supported ROS 2 distribution and architecture that can operate rclex_on_nerves.
+The "support" colomn refers to its status of official support as the ROS 2 distribution.
+
+| `ROS_DISTRO` | arm64v8 | arm32v7 | support |
+| :--- | :--- | :---| :---|
+| humble | ○ | ○ | LTS until May 2027 |
+| galactic | ○ | - | EOL at Dec 2022 |
+| foxy | ○ | ○ | EOL at Jun 2023 |
+
 ## Preliminaries
 
 During the procedure for Rclex on Nerves, the docker command is used to copy the necessary directory in `mix rclex.prep.ros2`.

--- a/lib/mix/tasks/rclex/prep/ros2.ex
+++ b/lib/mix/tasks/rclex/prep/ros2.ex
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.Rclex.Prep.Ros2 do
 
   @arm64v8_ros_distros ["foxy", "galactic", "humble"]
   @amd64_ros_distros ["foxy", "galactic", "humble"]
-  @arm32v7_ros_distros ["foxy"]
+  @arm32v7_ros_distros ["foxy", "humble"]
   @supported_ros_distros %{
     "arm64v8" => @arm64v8_ros_distros,
     "amd64" => @amd64_ros_distros,


### PR DESCRIPTION
本 PR ブランチを使用し、 RPI3 で `rclex_usage_on_nerves` の動作確認し、パブリッシュができていることを確認しました。

![image](https://github.com/rclex/rclex/assets/4096956/967fffc2-02f5-4469-b6d7-ba71387c71aa)