### PR TITLE
[WiP] support Iron Irwini

### DIFF
--- a/.github/workflows/ci_allver.yml
+++ b/.github/workflows/ci_allver.yml
@@ -14,13 +14,12 @@ jobs:
       matrix:
         dockertags: [
           latest,
+          iron-ex1.15.5-otp26.0.2,
           humble-ex1.15.5-otp26.0.2,
           humble-ex1.14.5-otp25.3.2.5,
           humble-ex1.13.4-otp25.0.3,
           galactic-ex1.15.5-otp26.0.2,
           foxy-ex1.15.5-otp26.0.2,
-          foxy-ex1.14.5-otp25.3.2.5,
-          foxy-ex1.13.4-otp25.0.3,
         ]
     container: rclex/rclex_docker:${{ matrix.dockertags }}
 


### PR DESCRIPTION
- [ ] add `iron-ex1.15.5-otp26.0.2` as new CI target, and remove foxy-ex13,14 (ref.) https://github.com/rclex/rclex_docker/pull/15
- [ ] fix Makefile to support iron
- [ ] check the operation on GHA and Nerves

This will fix #228 