### PR TITLE
release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## v0.9.1 on 12 Sep 2023
+
+**Full Changelog**: https://github.com/rclex/rclex/compare/v0.9.0...v0.9.1
+
+* New features:
+  * Experimental support for Iron Irwini by @takasehideki in https://github.com/rclex/rclex/pull/251
+* Code Improvements/Fixes: none
+* Bumps: none
+* Known issues to be addressed in the near future:
+  * Lock `git_hooks` to 0.6.5 due to its issue in https://github.com/rclex/rclex/issues/138
+  * Release rcl nif resources when GerServer terminates in https://github.com/rclex/rclex/issues/160
+  * `publish/2` sometimes failed just after `create_publisher/3` in https://github.com/rclex/rclex/issues/212
+  * CI fails randomly at mix test in https://github.com/rclex/rclex/issues/246
+  * Bump to Iron Irwini, for Docker and Nerves environments in https://github.com/rclex/rclex/issues/228
+* Note in this release:
+  * Please welcome Iron Irwini as the experimental supported distribution for Rclex!! :tada:
+
 ## v0.9.0 on 11 Sep 2023
 
 **Full Changelog**: https://github.com/rclex/rclex/compare/v0.8.5...v0.9.0

--- a/README_ja.md
+++ b/README_ja.md
@@ -82,7 +82,7 @@ cd rclex_usage
   defp deps do
     [
       ...
-      {:rclex, "~> 0.9.0"},
+      {:rclex, "~> 0.9.1"},
       ...
     ]
   end

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -67,7 +67,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
   defp deps do
     [
       ...
-      {:rclex, "~> 0.9.0"},
+      {:rclex, "~> 0.9.1"},
       ...
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Rclex.MixProject do
   ROS 2 Client Library for Elixir.
   """
 
-  @version "0.9.0"
+  @version "0.9.1"
   @source_url "https://github.com/rclex/rclex"
 
   def project do


### PR DESCRIPTION
**Full Changelog**: https://github.com/rclex/rclex/compare/v0.9.0...v0.9.1

* New features:
  * Experimental support for Iron Irwini by @takasehideki in https://github.com/rclex/rclex/pull/251
* Code Improvements/Fixes: none
* Bumps: none
* Known issues to be addressed in the near future:
  * Lock `git_hooks` to 0.6.5 due to its issue in https://github.com/rclex/rclex/issues/138
  * Release rcl nif resources when GerServer terminates in https://github.com/rclex/rclex/issues/160
  * `publish/2` sometimes failed just after `create_publisher/3` in https://github.com/rclex/rclex/issues/212
  * CI fails randomly at mix test in https://github.com/rclex/rclex/issues/246
  * Bump to Iron Irwini, for Docker and Nerves environments in https://github.com/rclex/rclex/issues/228
* Note in this release:
  * Please welcome Iron Irwini as the experimental supported distribution for Rclex!! :tada: