### PR TITLE
use nif allocator instead of rcl_default_allocator

### DIFF
--- a/src/allocator.c
+++ b/src/allocator.c
@@ -1,0 +1,42 @@
+#include "allocator.h"
+#include <erl_nif.h>
+#include <rcl/allocator.h>
+
+static void *__nif_allocate(size_t size, void *state) {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(NULL);
+
+  RCUTILS_UNUSED(state);
+  return enif_alloc(size);
+}
+
+static void __nif_deallocate(void *pointer, void *state) {
+  RCUTILS_UNUSED(state);
+  enif_free(pointer);
+}
+
+static void *__nif_reallocate(void *pointer, size_t size, void *state) {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(NULL);
+
+  RCUTILS_UNUSED(state);
+  return enif_realloc(pointer, size);
+}
+
+static void *__nif_zero_allocate(size_t number_of_elements, size_t size_of_element, void *state) {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(NULL);
+
+  RCUTILS_UNUSED(state);
+  void *mem = enif_alloc(number_of_elements * size_of_element);
+  memset((char *)mem, 0, number_of_elements * size_of_element);
+  return mem;
+}
+
+rcutils_allocator_t get_nif_allocator() {
+  static rcutils_allocator_t nif_allocator = {
+      .allocate      = __nif_allocate,
+      .deallocate    = __nif_deallocate,
+      .reallocate    = __nif_reallocate,
+      .zero_allocate = __nif_zero_allocate,
+      .state         = NULL,
+  };
+  return nif_allocator;
+}

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -1,0 +1,8 @@
+#ifndef ALLOCATOR_H
+#define ALLOCATOR_H
+
+#include "rmw/types.h"
+
+rcutils_allocator_t get_nif_allocator();
+
+#endif

--- a/src/rcl_clock.c
+++ b/src/rcl_clock.c
@@ -1,9 +1,9 @@
 #include "rcl_clock.h"
+#include "allocator.h"
 #include "macros.h"
 #include "resource_types.h"
 #include "terms.h"
 #include <erl_nif.h>
-#include <rcl/allocator.h>
 #include <rcl/time.h>
 #include <rcl/types.h>
 

--- a/src/rcl_init.c
+++ b/src/rcl_init.c
@@ -1,9 +1,9 @@
 #include "rcl_init.h"
+#include "allocator.h"
 #include "macros.h"
 #include "resource_types.h"
 #include "terms.h"
 #include <erl_nif.h>
-#include <rcl/allocator.h>
 #include <rcl/context.h>
 #include <rcl/init.h>
 #include <rcl/init_options.h>
@@ -17,7 +17,7 @@ ERL_NIF_TERM nif_rcl_init(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
 
   rcl_ret_t rc;
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
-  rcl_allocator_t allocator       = rcl_get_default_allocator();
+  rcl_allocator_t allocator       = get_nif_allocator();
   rcl_context_t context           = rcl_get_zero_initialized_context();
 
   rc = rcl_init_options_init(&init_options, allocator);

--- a/src/rcl_publisher.c
+++ b/src/rcl_publisher.c
@@ -1,4 +1,5 @@
 #include "rcl_publisher.h"
+#include "allocator.h"
 #include "qos.h"
 #include "resource_types.h"
 #include "terms.h"
@@ -45,6 +46,7 @@ ERL_NIF_TERM nif_rcl_publisher_init(ErlNifEnv *env, int argc, const ERL_NIF_TERM
   rcl_ret_t rc;
   rcl_publisher_t publisher                 = rcl_get_zero_initialized_publisher();
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
+  publisher_options.allocator               = get_nif_allocator();
   publisher_options.qos                     = qos;
 
   rc = rcl_publisher_init(&publisher, node_p, ts_p, topic_name, &publisher_options);

--- a/src/rcl_subscription.c
+++ b/src/rcl_subscription.c
@@ -1,4 +1,5 @@
 #include "rcl_subscription.h"
+#include "allocator.h"
 #include "qos.h"
 #include "resource_types.h"
 #include "terms.h"
@@ -45,6 +46,7 @@ ERL_NIF_TERM nif_rcl_subscription_init(ErlNifEnv *env, int argc, const ERL_NIF_T
   rcl_ret_t rc;
   rcl_subscription_t subscription                 = rcl_get_zero_initialized_subscription();
   rcl_subscription_options_t subscription_options = rcl_subscription_get_default_options();
+  subscription_options.allocator                  = get_nif_allocator();
   subscription_options.qos                        = qos;
 
   rc = rcl_subscription_init(&subscription, node_p, ts_p, topic_name, &subscription_options);

--- a/src/rcl_timer.c
+++ b/src/rcl_timer.c
@@ -1,8 +1,8 @@
 #include "rcl_timer.h"
+#include "allocator.h"
 #include "resource_types.h"
 #include "terms.h"
 #include <erl_nif.h>
-#include <rcl/allocator.h>
 #include <rcl/context.h>
 #include <rcl/time.h>
 #include <rcl/timer.h>
@@ -30,7 +30,7 @@ ERL_NIF_TERM nif_rcl_timer_init(ErlNifEnv *env, int argc, const ERL_NIF_TERM arg
   rcl_timer_t timer = rcl_get_zero_initialized_timer();
 
   rc = rcl_timer_init(&timer, clock_p, context_p, RCL_MS_TO_NS(period_ms), NULL,
-                      rcl_get_default_allocator());
+                      get_nif_allocator());
   if (rc != RCL_RET_OK) return enif_make_badarg(env);
 
   rcl_timer_t *obj  = enif_alloc_resource(rt_rcl_timer_t, sizeof(rcl_timer_t));

--- a/src/rcl_wait.c
+++ b/src/rcl_wait.c
@@ -1,8 +1,8 @@
 #include "rcl_wait.h"
+#include "allocator.h"
 #include "resource_types.h"
 #include "terms.h"
 #include <erl_nif.h>
-#include <rcl/allocator.h>
 #include <rcl/context.h>
 #include <rcl/subscription.h>
 #include <rcl/time.h>
@@ -45,7 +45,7 @@ ERL_NIF_TERM nif_rcl_wait_set_init_timer(ErlNifEnv *env, int argc, const ERL_NIF
   rcl_ret_t rc;
 
   rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
-  rc = rcl_wait_set_init(&wait_set, 0, 0, 1, 0, 0, 0, context_p, rcl_get_default_allocator());
+  rc = rcl_wait_set_init(&wait_set, 0, 0, 1, 0, 0, 0, context_p, get_nif_allocator());
   if (rc != RCL_RET_OK) return raise(env, __FILE__, __LINE__);
 
   rcl_wait_set_t *obj = enif_alloc_resource(rt_rcl_wait_set_t, sizeof(rcl_wait_set_t));


### PR DESCRIPTION
Use the internal erlang memory allocators, which means that memory that is already available in the internal VM cache can be reuse instead of doing a system call to get memory. This can lead to faster memory allocation in some cases - currently rcl by default uses `std::malloc()`, `std::free()` and `std::realloc()`. BEAM gets aware of the memory allocated by rclex and makes it visible via Erlang functions like `erlang:memory/1`.