### PR TITLE
add buildin support for byte type

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,6 +6,5 @@ config :rclex,
     "std_msgs/msg/UInt32MultiArray",
     "geometry_msgs/msg/Twist",
     "sensor_msgs/msg/PointCloud",
-    "diagnostic_msgs/msg/KeyValue",
     "diagnostic_msgs/msg/DiagnosticStatus"
   ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,5 +5,7 @@ config :rclex,
     "std_msgs/msg/String",
     "std_msgs/msg/UInt32MultiArray",
     "geometry_msgs/msg/Twist",
-    "sensor_msgs/msg/PointCloud"
+    "sensor_msgs/msg/PointCloud",
+    "diagnostic_msgs/msg/KeyValue",
+    "diagnostic_msgs/msg/DiagnosticStatus"
   ]

--- a/lib/rclex/generators/msg_c.ex
+++ b/lib/rclex/generators/msg_c.ex
@@ -212,6 +212,15 @@ defmodule Rclex.Generators.MsgC do
     """
   end
 
+  defp enif_get_builtin("byte" <> _, var, mbr, term) do
+    """
+    int #{var};
+    if (!enif_get_int(env, #{term}, &#{var}))
+      return enif_make_badarg(env);
+    message_p->#{mbr} = (uint8_t)#{var};
+    """
+  end
+
   defp enif_get_builtin("int" <> _, var, mbr, term) do
     """
     int #{var};
@@ -373,6 +382,10 @@ defmodule Rclex.Generators.MsgC do
 
   defp enif_make_builtin("int64", mbr) do
     "enif_make_int64(env, message_p->#{mbr})"
+  end
+
+  defp enif_make_builtin("byte" <> _, mbr) do
+    "enif_make_int(env, message_p->#{mbr})"
   end
 
   defp enif_make_builtin("int" <> _, mbr) do

--- a/lib/rclex/generators/msg_c.ex
+++ b/lib/rclex/generators/msg_c.ex
@@ -212,12 +212,12 @@ defmodule Rclex.Generators.MsgC do
     """
   end
 
-  defp enif_get_builtin("byte" <> _, var, mbr, term) do
+  defp enif_get_builtin("byte", var, mbr, term) do
     """
-    int #{var};
-    if (!enif_get_int(env, #{term}, &#{var}))
+    uint8_t #{var};
+    if (!enif_get_uint(env, #{term}, (unsigned int *)&#{var}))
       return enif_make_badarg(env);
-    message_p->#{mbr} = (uint8_t)#{var};
+    message_p->#{mbr} = #{var};
     """
   end
 
@@ -384,8 +384,8 @@ defmodule Rclex.Generators.MsgC do
     "enif_make_int64(env, message_p->#{mbr})"
   end
 
-  defp enif_make_builtin("byte" <> _, mbr) do
-    "enif_make_int(env, message_p->#{mbr})"
+  defp enif_make_builtin("byte", mbr) do
+    "enif_make_uint(env, message_p->#{mbr})"
   end
 
   defp enif_make_builtin("int" <> _, mbr) do

--- a/test/rclex/parsers/message_parser_test.exs
+++ b/test/rclex/parsers/message_parser_test.exs
@@ -91,6 +91,7 @@ defmodule Rclex.Parsers.MessageParserTest do
     end
 
     for {text, expected} <- [
+          {"byte STALE=3", [{:builtin_type, "byte"}, "STALE", "=", 3]},
           {"int32 X=123", [{:builtin_type, "int32"}, "X", "=", 123]},
           {"int32 Y=-123", [{:builtin_type, "int32"}, "Y", "=", -123]},
           {"string FOO=\"foo\"", [{:builtin_type, "string"}, "FOO", "=", "foo"]},

--- a/test/rclex/pkgs/test.exs
+++ b/test/rclex/pkgs/test.exs
@@ -74,7 +74,10 @@ defmodule Rclex.Pkgs.Test do
       name: "test",
       message: "test message",
       hardware_id: "test sensor",
-      values: [%Rclex.Pkgs.DiagnosticMsgs.Msg.KeyValue{key: "key1", value: "value1"}, %Rclex.Pkgs.DiagnosticMsgs.Msg.KeyValue{key: "key2", value: "value2"}]
+      values: [
+        %Rclex.Pkgs.DiagnosticMsgs.Msg.KeyValue{key: "key1", value: "value1"},
+        %Rclex.Pkgs.DiagnosticMsgs.Msg.KeyValue{key: "key2", value: "value2"}
+      ]
     }
 
     Rclex.Pkgs.DiagnosticMsgs.Msg.DiagnosticStatus.create!()

--- a/test/rclex/pkgs/test.exs
+++ b/test/rclex/pkgs/test.exs
@@ -67,4 +67,21 @@ defmodule Rclex.Pkgs.Test do
     end)
     |> tap(&Rclex.Pkgs.SensorMsgs.Msg.PointCloud.destroy!(&1))
   end
+
+  test "diagnostic_msgs/msg/DiagnosticStatus" do
+    struct = %Rclex.Pkgs.DiagnosticMsgs.Msg.DiagnosticStatus{
+      level: 3,
+      name: "test",
+      message: "test message",
+      hardware_id: "test sensor",
+      values: [%Rclex.Pkgs.DiagnosticMsgs.Msg.KeyValue{key: "key1", value: "value1"}, %Rclex.Pkgs.DiagnosticMsgs.Msg.KeyValue{key: "key2", value: "value2"}]
+    }
+
+    Rclex.Pkgs.DiagnosticMsgs.Msg.DiagnosticStatus.create!()
+    |> tap(&Rclex.Pkgs.DiagnosticMsgs.Msg.DiagnosticStatus.set!(&1, struct))
+    |> tap(fn message ->
+      assert ^struct = Rclex.Pkgs.DiagnosticMsgs.Msg.DiagnosticStatus.get!(message)
+    end)
+    |> tap(&Rclex.Pkgs.DiagnosticMsgs.Msg.DiagnosticStatus.destroy!(&1))
+  end
 end


### PR DESCRIPTION
Hello @takasehideki and @pojiro,
for the message type [DiagnosticStatus](https://docs.ros.org/en/api/diagnostic_msgs/html/msg/DiagnosticStatus.html) the message generation was giving me problems for the primitive ros type _byte_ for not being recognised as a buildin type.
What would be the preferred approach here? I'm not sure, if adding it as a buildin type is the right way because it just maps to uint8.
Best regards,
Felix