### PR TITLE
Update docs for 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,25 +145,17 @@ Here is the simplest implementation example `lib/rclex_usage.ex` that will publi
 
 ```elixir
 defmodule RclexUsage do
+  alias Rclex.Pkgs.StdMsgs
+
   def publish_message do
-    context = Rclex.rclexinit()
-    {:ok, node} = Rclex.ResourceServer.create_node(context, 'talker')
-    {:ok, publisher} = Rclex.Node.create_publisher(node, 'StdMsgs.Msg.String', 'chatter')
+    Rclex.start_node("talker")
+    Rclex.start_publisher(StdMsgs.Msg.String, "/chatter", "talker")
 
-    msg = Rclex.Msg.initialize('StdMsgs.Msg.String')
     data = "Hello World from Rclex!"
-    msg_struct = %Rclex.StdMsgs.Msg.String{data: String.to_charlist(data)}
-    Rclex.Msg.set(msg, msg_struct, 'StdMsgs.Msg.String')
-
-    # This sleep is essential for now, see Issue #212
-    Process.sleep(100)
+    msg = struct(StdMsgs.Msg.String, %{data: data})
 
     IO.puts("Rclex: Publishing: #{data}")
-    Rclex.Publisher.publish([publisher], [msg])
-
-    Rclex.Node.finish_job(publisher)
-    Rclex.ResourceServer.finish_node(node)
-    Rclex.shutdown(context)
+    Rclex.publish(msg, "/chatter", "talker")
   end
 end
 ```
@@ -182,18 +174,8 @@ Operate the following command on IEx.
 
 ```
 iex()> RclexUsage.publish_message
-
-00:04:40.701 [debug] JobExecutor start
- 
-00:04:40.705 [debug] talker0/chatter/pub
 Rclex: Publishing: Hello World from Rclex!
-
-00:04:40.706 [debug] publish ok
- 
-00:04:40.706 [debug] publisher finished: talker0/chatter/pub
- 
-00:04:40.710 [debug] finish node: talker0
-{:ok, #Reference<0.2970499651.1284374532.3555>}
+:ok
 ```
 
 You can confirm the above operation by subscribing with `ros2 topic echo` from the other terminal.

--- a/README_ja.md
+++ b/README_ja.md
@@ -130,25 +130,17 @@ mix rclex.gen.msgs
 
 ```elixir
 defmodule RclexUsage do
+  alias Rclex.Pkgs.StdMsgs
+
   def publish_message do
-    context = Rclex.rclexinit()
-    {:ok, node} = Rclex.ResourceServer.create_node(context, 'talker')
-    {:ok, publisher} = Rclex.Node.create_publisher(node, 'StdMsgs.Msg.String', 'chatter')
+    Rclex.start_node("talker")
+    Rclex.start_publisher(StdMsgs.Msg.String, "/chatter", "talker")
 
-    msg = Rclex.Msg.initialize('StdMsgs.Msg.String')
     data = "Hello World from Rclex!"
-    msg_struct = %Rclex.StdMsgs.Msg.String{data: String.to_charlist(data)}
-    Rclex.Msg.set(msg, msg_struct, 'StdMsgs.Msg.String')
-
-    # This sleep is essential for now, see Issue #212
-    Process.sleep(100)
+    msg = struct(StdMsgs.Msg.String, %{data: data})
 
     IO.puts("Rclex: Publishing: #{data}")
-    Rclex.Publisher.publish([publisher], [msg])
-
-    Rclex.Node.finish_job(publisher)
-    Rclex.ResourceServer.finish_node(node)
-    Rclex.shutdown(context)
+    Rclex.publish(msg, "/chatter", "talker")
   end
 end
 ```
@@ -167,18 +159,8 @@ IEx上で次のように実行してください．
 
 ```
 iex()> RclexUsage.publish_message
-
-00:04:40.701 [debug] JobExecutor start
- 
-00:04:40.705 [debug] talker0/chatter/pub
 Rclex: Publishing: Hello World from Rclex!
-
-00:04:40.706 [debug] publish ok
- 
-00:04:40.706 [debug] publisher finished: talker0/chatter/pub
- 
-00:04:40.710 [debug] finish node: talker0
-{:ok, #Reference<0.2970499651.1284374532.3555>}
+:ok
 ```
 
 このメッセージの出版結果は，ROS 2コマンド`ros2 topic echo`によって購読して確認できます．

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -166,25 +166,17 @@ Here is the simplest implementation example `lib/rclex_usage_on_nerves.ex` that 
 
 ```elixir
 defmodule RclexUsageOnNerves do
+  alias Rclex.Pkgs.StdMsgs
+
   def publish_message do
-    context = Rclex.rclexinit()
-    {:ok, node} = Rclex.ResourceServer.create_node(context, 'talker')
-    {:ok, publisher} = Rclex.Node.create_publisher(node, 'StdMsgs.Msg.String', 'chatter')
+    Rclex.start_node("talker")
+    Rclex.start_publisher(StdMsgs.Msg.String, "/chatter", "talker")
 
-    msg = Rclex.Msg.initialize('StdMsgs.Msg.String')
     data = "Hello World from Rclex!"
-    msg_struct = %Rclex.StdMsgs.Msg.String{data: String.to_charlist(data)}
-    Rclex.Msg.set(msg, msg_struct, 'StdMsgs.Msg.String')
-
-    # This sleep is essential for now, see Issue #212
-    Process.sleep(100)
+    msg = struct(StdMsgs.Msg.String, %{data: data})
 
     IO.puts("Rclex: Publishing: #{data}")
-    Rclex.Publisher.publish([publisher], [msg])
-
-    Rclex.Node.finish_job(publisher)
-    Rclex.ResourceServer.finish_node(node)
-    Rclex.shutdown(context)
+    Rclex.publish(msg, "/chatter", "talker")
   end
 end
 ```
@@ -213,7 +205,7 @@ Operate the following command on IEx.
 ```
 iex()> RclexUsageOnNerves.publish_message
 Rclex: Publishing: Hello World from Rclex!
-{:ok, #Reference<0.2970499651.1284374532.3555>}
+:ok
 ```
 
 You can confirm the above operation by subscribing with `ros2 topic echo` on the machine where ROS 2 env has been installed.

--- a/lib/rclex.ex
+++ b/lib/rclex.ex
@@ -1,9 +1,30 @@
 defmodule Rclex do
   @moduledoc """
-  User API of `Rclex`.
+  User API for `#{__MODULE__}`.
   """
 
-  @spec start_node(name :: String.t(), opts :: list()) ::
+  @namespace_doc "`:namespace` must lead with \"/\". if not specified, the default is \"/\""
+  @qos_doc "`:qos` if not specified, applied the default which equals return of `Rclex.QoS.profile_default/0`"
+  @topic_name_doc "`topic_name` must lead with \"/\""
+
+  @typedoc "#{@topic_name_doc}."
+  @type topic_name :: String.t()
+
+  @doc """
+  Start node.
+
+  ### opts
+
+  - #{@namespace_doc}
+
+  ## Examples
+
+      iex> Rclex.start_node("node", namespace: "/example")
+      :ok
+      iex> Rclex.start_node("node", namespace: "/example")
+      {:error, :already_started}
+  """
+  @spec start_node(name :: String.t(), opts :: [namespace: String.t()]) ::
           :ok | {:error, :already_started} | {:error, term()}
   def start_node(name, opts \\ []) when is_binary(name) and is_list(opts) do
     context = Rclex.Context.get()
@@ -16,37 +37,82 @@ defmodule Rclex do
     end
   end
 
-  @spec stop_node(name :: String.t(), opts :: list()) ::
+  @doc """
+  Stop node. And also stop the entities on the node, `publisher`, `subscription` and `timer`.
+
+  ### opts
+
+  - #{@namespace_doc}
+
+  ## Examples
+
+      iex> Rclex.stop_node("node", namespace: "/example")
+      :ok
+      iex> Rclex.stop_node("node", namespace: "/example")
+      {:error, :not_found}
+  """
+  @spec stop_node(name :: String.t(), opts :: [namespace: String.t()]) ::
           :ok | {:error, :not_found}
   def stop_node(name, opts \\ []) when is_binary(name) and is_list(opts) do
     namespace = Keyword.get(opts, :namespace, "/")
     Rclex.NodesSupervisor.terminate_child(name, namespace)
   end
 
+  @doc """
+  Start publisher.
+
+  - #{@topic_name_doc}
+
+  ## Examples
+
+      iex> alias Rclex.Pkgs.StdMsgs
+      iex> Rclex.start_publisher(StdMsgs.Msg.String, "/chatter", "node", namespace: "/example")
+      :ok
+      iex> Rclex.start_publisher(StdMsgs.Msg.String, "/chatter", "node", namespace: "/example")
+      {:error, :already_started}
+  """
   @spec start_publisher(
           message_type :: module(),
-          topic_name :: String.t(),
-          name :: String.t(),
-          opts :: list()
+          topic_name :: topic_name(),
+          node_name :: String.t(),
+          opts :: [namespace: String.t(), qos: Rclex.QoS.t()]
         ) ::
           :ok | {:error, :already_started} | {:error, term()}
-  def start_publisher(message_type, topic_name, name, opts \\ [])
-      when is_atom(message_type) and is_binary(topic_name) and is_binary(name) and is_list(opts) do
+  def start_publisher(message_type, topic_name, node_name, opts \\ [])
+      when is_atom(message_type) and is_binary(topic_name) and is_binary(node_name) and
+             is_list(opts) do
     namespace = Keyword.get(opts, :namespace, "/")
     qos = Keyword.get(opts, :qos, Rclex.QoS.profile_default())
 
-    case Rclex.Node.start_publisher(message_type, topic_name, name, namespace, qos) do
+    case Rclex.Node.start_publisher(message_type, topic_name, node_name, namespace, qos) do
       {:ok, _pid} -> :ok
       {:error, {:already_started, _pid}} -> {:error, :already_started}
       {:error, reason} -> {:error, reason}
     end
   end
 
+  @doc """
+  Stop publisher.
+
+  - #{@topic_name_doc}
+
+  ### opts
+
+  - #{@namespace_doc}
+
+  ## Examples
+
+      iex> alias Rclex.Pkgs.StdMsgs
+      iex> Rclex.stop_publisher(StdMsgs.Msg.String, "/chatter", "node", namespace: "/example")
+      :ok
+      iex> Rclex.stop_publisher(StdMsgs.Msg.String, "/chatter", "node", namespace: "/example")
+      {:error, :not_found}
+  """
   @spec stop_publisher(
           message_type :: module(),
-          topic_name :: String.t(),
-          name :: String.t(),
-          opts :: list()
+          topic_name :: topic_name(),
+          node_name :: String.t(),
+          opts :: [namespace: String.t()]
         ) ::
           :ok | {:error, :not_found}
   def stop_publisher(message_type, topic_name, name, opts \\ [])
@@ -55,82 +121,169 @@ defmodule Rclex do
     Rclex.Node.stop_publisher(message_type, topic_name, name, namespace)
   end
 
+  @doc """
+  Publish message.
+
+  - #{@topic_name_doc}
+
+  ### opts
+
+  - #{@namespace_doc}
+
+  ## Examples
+
+      iex> alias Rclex.Pkgs.StdMsgs
+      iex> Rclex.publish(struct(StdMsgs.Msg.String, %{data: "hello"}), "/chatter", "node", namespace: "/example")
+      :ok
+      iex> Rclex.publish(struct(StdMsgs.Msg.String, %{data: "hello"}), "/chatter", "node")
+      {:error, :not_found}
+  """
   @spec publish(
           message :: struct(),
-          topic_name :: String.t(),
-          name :: String.t(),
-          opts :: list()
-        ) ::
-          :ok
-  def publish(message, topic_name, name, opts \\ [])
-      when is_struct(message) and is_binary(topic_name) and is_binary(name) and is_list(opts) do
+          topic_name :: topic_name(),
+          node_name :: String.t(),
+          opts :: [namespace: String.t()]
+        ) :: :ok | {:error, :not_found}
+  def publish(message, topic_name, node_name, opts \\ [])
+      when is_struct(message) and is_binary(topic_name) and is_binary(node_name) and is_list(opts) do
     namespace = Keyword.get(opts, :namespace, "/")
-    Rclex.Publisher.publish(message, topic_name, name, namespace)
+    Rclex.Publisher.publish(message, topic_name, node_name, namespace)
   end
 
+  @doc """
+  Start subscription.
+
+  - #{@topic_name_doc}
+
+  ### opts
+
+  - #{@namespace_doc}
+  - #{@qos_doc}
+
+  ## Examples
+
+      iex> alias Rclex.Pkgs.StdMsgs
+      iex> Rclex.start_subscription(&IO.inspect/1, StdMsgs.Msg.String, "/chatter", "node", namespace: "/example")
+      :ok
+      iex> Rclex.start_subscription(&IO.inspect/1, StdMsgs.Msg.String, "/chatter", "node", namespace: "/example")
+      {:error, :already_started}
+  """
   @spec start_subscription(
           callback :: function(),
           message_type :: module(),
-          topic_name :: String.t(),
-          name :: String.t(),
-          opts :: list()
+          topic_name :: topic_name(),
+          node_name :: String.t(),
+          opts :: [namespace: String.t(), qos: Rclex.QoS.t()]
         ) ::
           :ok | {:error, :already_started} | {:error, term()}
-  def start_subscription(callback, message_type, topic_name, name, opts \\ [])
+  def start_subscription(callback, message_type, topic_name, node_name, opts \\ [])
       when is_function(callback) and is_atom(message_type) and is_binary(topic_name) and
-             is_binary(name) and is_list(opts) do
+             is_binary(node_name) and is_list(opts) do
     namespace = Keyword.get(opts, :namespace, "/")
     qos = Keyword.get(opts, :qos, Rclex.QoS.profile_default())
 
-    case Rclex.Node.start_subscription(callback, message_type, topic_name, name, namespace, qos) do
+    case Rclex.Node.start_subscription(
+           callback,
+           message_type,
+           topic_name,
+           node_name,
+           namespace,
+           qos
+         ) do
       {:ok, _pid} -> :ok
       {:error, {:already_started, _pid}} -> {:error, :already_started}
       {:error, reason} -> {:error, reason}
     end
   end
 
+  @doc """
+  Stop subscription.
+
+  - #{@topic_name_doc}
+
+  ### opts
+
+  - #{@namespace_doc}
+
+  ## Examples
+
+      iex> alias Rclex.Pkgs.StdMsgs
+      iex> Rclex.stop_subscription(StdMsgs.Msg.String, "/chatter", "node", namespace: "/example")
+      :ok
+      iex> Rclex.stop_subscription(StdMsgs.Msg.String, "/chatter", "node", namespace: "/example")
+      {:error, :not_found}
+  """
   @spec stop_subscription(
           message_type :: module(),
-          topic_name :: String.t(),
-          name :: String.t(),
-          opts :: list()
+          topic_name :: topic_name(),
+          node_name :: String.t(),
+          opts :: [namespace: String.t()]
         ) ::
           :ok | {:error, :not_found}
-  def stop_subscription(message_type, topic_name, name, opts \\ [])
-      when is_atom(message_type) and is_binary(topic_name) and is_binary(name) and is_list(opts) do
+  def stop_subscription(message_type, topic_name, node_name, opts \\ [])
+      when is_atom(message_type) and is_binary(topic_name) and is_binary(node_name) and
+             is_list(opts) do
     namespace = Keyword.get(opts, :namespace, "/")
-    Rclex.Node.stop_subscription(message_type, topic_name, name, namespace)
+    Rclex.Node.stop_subscription(message_type, topic_name, node_name, namespace)
   end
 
+  @doc """
+  Start timer.
+
+  ### opts
+
+  - #{@namespace_doc}
+
+  ## Examples
+
+      iex> Rclex.start_timer(1000, fn -> IO.inspect("tick") end, "tick", "node", namespace: "/example")
+      :ok
+      iex> Rclex.start_timer(1000, fn -> IO.inspect("tick") end, "tick", "node", namespace: "/example")
+      {:error, :already_started}
+  """
   @spec start_timer(
           period_ms :: non_neg_integer(),
           callback :: function(),
           timer_name :: String.t(),
-          name :: String.t(),
-          opts :: list()
+          node_name :: String.t(),
+          opts :: [namespace: String.t()]
         ) ::
           :ok | {:error, :already_started} | {:error, term()}
-  def start_timer(period_ms, callback, timer_name, name, opts \\ [])
+  def start_timer(period_ms, callback, timer_name, node_name, opts \\ [])
       when is_integer(period_ms) and is_function(callback) and is_binary(timer_name) and
-             is_binary(name) and is_list(opts) do
+             is_binary(node_name) and is_list(opts) do
     namespace = Keyword.get(opts, :namespace, "/")
 
-    case Rclex.Node.start_timer(period_ms, callback, timer_name, name, namespace) do
+    case Rclex.Node.start_timer(period_ms, callback, timer_name, node_name, namespace) do
       {:ok, _pid} -> :ok
       {:error, {:already_started, _pid}} -> {:error, :already_started}
       {:error, reason} -> {:error, reason}
     end
   end
 
+  @doc """
+  Stop timer.
+
+  ### opts
+
+  - #{@namespace_doc}
+
+  ## Examples
+
+      iex> Rclex.stop_timer("tick", "node", namespace: "/example")
+      :ok
+      iex> Rclex.stop_timer("tick", "node", namespace: "/example")
+      {:error, :not_found}
+  """
   @spec stop_timer(
           timer_name :: String.t(),
-          name :: String.t(),
-          opts :: list()
+          node_name :: String.t(),
+          opts :: [namespace: String.t()]
         ) ::
           :ok | {:error, :not_found}
-  def stop_timer(timer_name, name, opts \\ [])
-      when is_binary(timer_name) and is_binary(name) and is_list(opts) do
+  def stop_timer(timer_name, node_name, opts \\ [])
+      when is_binary(timer_name) and is_binary(node_name) and is_list(opts) do
     namespace = Keyword.get(opts, :namespace, "/")
-    Rclex.Node.stop_timer(timer_name, name, namespace)
+    Rclex.Node.stop_timer(timer_name, node_name, namespace)
   end
 end

--- a/lib/rclex/publisher.ex
+++ b/lib/rclex/publisher.ex
@@ -21,8 +21,11 @@ defmodule Rclex.Publisher do
   end
 
   def publish(%message_type{} = message, topic_name, name, namespace \\ "/") do
-    server = name(message_type, topic_name, name, namespace)
-    GenServer.call(server, {:publish, message})
+    case GenServer.whereis(name(message_type, topic_name, name, namespace)) do
+      nil -> {:error, :not_found}
+      {_atom, _node} -> raise("should not happen")
+      pid -> GenServer.call(pid, {:publish, message})
+    end
   end
 
   # callbacks

--- a/lib/rclex/qos.ex
+++ b/lib/rclex/qos.ex
@@ -9,13 +9,13 @@ defmodule Rclex.QoS do
   - `deadline`, `lifespan`, `liveliness_lease_duration` should be specified by float seconds.
   """
   @type t() :: %__MODULE__{
-          history: :system_default | :keep_last | :keep_all | :unknown,
+          history: :system_default | :keep_last | :keep_all,
           depth: non_neg_integer(),
-          reliability: :system_default | :reliable | :best_effort | :unknown,
-          durability: :system_default | :transient_local | :volatile | :unknown,
+          reliability: :system_default | :reliable | :best_effort,
+          durability: :system_default | :transient_local | :volatile,
           deadline: float(),
           lifespan: float(),
-          liveliness: :system_default | :automatic | :manual_by_topic | :unknown,
+          liveliness: :system_default | :automatic | :manual_by_topic,
           liveliness_lease_duration: float(),
           avoid_ros_namespace_conventions: boolean()
         }

--- a/lib/rclex/qos.ex
+++ b/lib/rclex/qos.ex
@@ -1,6 +1,13 @@
 defmodule Rclex.QoS do
-  @moduledoc false
+  @moduledoc """
+  Documentation for `#{__MODULE__}`.
 
+  See also [Quality of Service settings](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Quality-of-Service-Settings.html) on ROS 2 Documentation.
+  """
+
+  @typedoc """
+  - `deadline`, `lifespan`, `liveliness_lease_duration` should be specified by float seconds.
+  """
   @type t() :: %__MODULE__{
           history: :system_default | :keep_last | :keep_all | :unknown,
           depth: non_neg_integer(),
@@ -23,10 +30,27 @@ defmodule Rclex.QoS do
             liveliness_lease_duration: 0.0,
             avoid_ros_namespace_conventions: false
 
+  @doc "For sensor data, in most cases it’s more important to receive readings in a timely fashion, rather than ensuring that all of them arrive. That is, developers want the latest samples as soon as they are captured, at the expense of maybe losing some. For that reason the sensor data profile uses best effort reliability and a smaller queue size."
+  @spec profile_sensor_data() :: t()
   defdelegate profile_sensor_data(), to: Rclex.Nif, as: :rmw_qos_profile_sensor_data!
+
+  @doc "Parameters in ROS 2 are based on services, and as such have a similar profile. The difference is that parameters use a much larger queue depth so that requests do not get lost when, for example, the parameter client is unable to reach the parameter service server"
+  @spec profile_parameters() :: t()
   defdelegate profile_parameters(), to: Rclex.Nif, as: :rmw_qos_profile_parameters!
+
+  @doc "Default QoS settings for publishers and subscriptions"
+  @spec profile_default() :: t()
   defdelegate profile_default(), to: Rclex.Nif, as: :rmw_qos_profile_default!
+
+  @doc "In the same vein as publishers and subscriptions, services are reliable. It is especially important for services to use volatile durability, as otherwise service servers that re-start may receive outdated requests. While the client is protected from receiving multiple responses, the server is not protected from side-effects of receiving the outdated requests."
+  @spec profile_services_default() :: t()
   defdelegate profile_services_default(), to: Rclex.Nif, as: :rmw_qos_profile_services_default!
+
+  @doc false
+  @spec profile_parameter_events() :: t()
   defdelegate profile_parameter_events(), to: Rclex.Nif, as: :rmw_qos_profile_parameter_events!
+
+  @doc "This uses the RMW implementation’s default values for all of the policies. Different RMW implementations may have different defaults."
+  @spec profile_system_default() :: t()
   defdelegate profile_system_default(), to: Rclex.Nif, as: :rmw_qos_profile_system_default!
 end


### PR DESCRIPTION
Here is the start point to refine docs for v0.10.0

この PR は README.md, README_ja.md, USE_ON_NERVES.md および Rclex のユーザ API のドキュメントをリファインすることをスコープとしています。それ以外に気づいたことは、別 PR でやりましょう。

@takasehideki @s-hosoai **review timing is up to you, i don't mind.**

### 相談ポイント

- README.md 内の https://github.com/rclex/rclex_examples, https://github.com/rclex/rclex_connection_tests の扱いをどうするか
  - rclex_connection_tests は ローカルネットワークレベルであれば、 https://github.com/rclex/rclex/blob/0.10.0-dev/test/rclex_test.exs#L138-L161 でテストしています。
- README_ja.md の README.md キャッチアップ漏れ（v0.9.3 までの修正点）
  - 二重メンテを考えると README.md にしぼる案も？
