### PR TITLE
bump CI targets according to https://github.com/rclex/rclex_docker/pull/17

### DIFF
--- a/.github/workflows/ci-all_version.yml
+++ b/.github/workflows/ci-all_version.yml
@@ -16,7 +16,8 @@ jobs:
           latest,
           # WHY commented out: see https://github.com/rclex/rclex/issues/228#issuecomment-1715288806
           #iron-ex1.15.5-otp26.0.2,
-          humble-ex1.15.5-otp26.0.2,
+          humble-ex1.16.2-otp26.2.2,
+          humble-ex1.15.7-otp26.2.2,
           humble-ex1.14.5-otp25.3.2.5,
           foxy-ex1.15.5-otp26.0.2,
         ]

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ The basic and recommended environment is where the host (development) and the ta
 
 Currently, we use the following environment as the main development target:
 
-- Ubuntu 22.04.3 LTS (Jammy Jellyfish)
+- Ubuntu 22.04.4 LTS (Jammy Jellyfish)
 - ROS 2 [Humble Hawksbill](https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html)
-- Elixir 1.15.5-otp-26
-- Erlang/OTP 26.0.2
+- Elixir 1.15.7-otp-26
+- Erlang/OTP 26.2.2
 
 We highly recommend using Humble for ROS 2 LTS distribution.
 Iron, the STS distribution, is experimentally supported and confirmed for the proper operation only in the native environment. See detail and status on [Issue#228](https://github.com/rclex/rclex/issues/228#issuecomment-1715293177).

--- a/README_ja.md
+++ b/README_ja.md
@@ -34,10 +34,10 @@ ROS 2の主な貢献として，通信にDDS（Data Distribution Service）プ�
 
 現在，下記の環境を主な対象として開発を進めています．
 
-- Ubuntu 22.04.3 LTS (Jammy Jellyfish)
+- Ubuntu 22.04.4 LTS (Jammy Jellyfish)
 - ROS 2 [Humble Hawksbill](https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html)
-- Elixir 1.15.5-otp-26
-- Erlang/OTP 26.0.2
+- Elixir 1.15.7-otp-26
+- Erlang/OTP 26.2.2
 
 ROS 2には長期サポート版（LTS）であるHumbleの利用を強く推奨します．
 短期サポート版（STS）のIronは，実験的なサポートでありネイティブ環境での基本的な動作のみを確認しています．対応状況の詳細は[Issue#228](https://github.com/rclex/rclex/issues/228#issuecomment-1715293177)を確認してください．


### PR DESCRIPTION
ref: https://github.com/rclex/rclex_docker/pull/17

This PR changes the `latest` tag that contains the recommended tool versions for Rclex to `humble-ex1.15.7-otp26.2.2`.
Also, `humble-ex1.16.2-otp26.2.2` is added, and some older tags are sorted out.

- Humble Hawksbill (**LTS rosdistro until May 2027**)
  - humble-ex1.16.2-otp26.2.2
  - humble-ex1.15.7-otp26.2.2 **[latest]**
  - humble-ex1.14.5-otp25.3.2.5
- Foxy Fitzroy (_EOL!_)
  - foxy-ex1.15.5-otp26.0.2
- [experimental] Iron Irwini (_STS until Nov 2024_)
  - iron-ex1.15.5-otp26.0.2

I will merge this PR after confirming these operations with the Rclex CI test.