### PR TITLE
Use `rcl_subscription_set_on_new_message_callback`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ $(NIF_SO): $(OBJ)
 	$(CC) -o $@ $^ $(LDFLAGS) $(ERL_LDFLAGS) $(ROS_LDFLAGS)
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c Makefile $(SRC_H)
-	$(CC) -o $@ -c $(CFLAGS) $(ERL_CFLAGS) $(ROS_CFLAGS) $<
+	$(CC) -DROS_DISTRO_$(ROS_DISTRO) -o $@ -c $(CFLAGS) $(ERL_CFLAGS) $(ROS_CFLAGS) $<
 
 $(OBJ_DIR) $(PRIV_DIR) $(MSG_OBJ_DIR):
 	@mkdir -p $@

--- a/lib/rclex/nif.ex
+++ b/lib/rclex/nif.ex
@@ -60,6 +60,14 @@ defmodule Rclex.Nif do
     :erlang.nif_error(:nif_not_loaded)
   end
 
+  def rcl_subscription_set_on_new_message_callback!(_subscription) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  def rcl_subscription_clear_message_callback!(_subscription, _callback_resource) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
   def rcl_clock_init!() do
     :erlang.nif_error(:nif_not_loaded)
   end

--- a/lib/rclex/subscription.ex
+++ b/lib/rclex/subscription.ex
@@ -39,16 +39,9 @@ defmodule Rclex.Subscription do
     type_support = apply(message_type, :type_support!, [])
     subscription = Nif.rcl_subscription_init!(node, type_support, ~c"#{topic_name}", qos)
 
-    callback_resource =
-      if System.fetch_env!("ROS_DISTRO") == "foxy" do
-        send(self(), :take)
-        Nif.rcl_wait_set_init_subscription!(context)
-      else
-        Nif.rcl_subscription_set_on_new_message_callback!(subscription)
-      end
-
     {:ok,
      %{
+       context: context,
        node: node,
        message_type: message_type,
        topic_name: topic_name,
@@ -56,77 +49,100 @@ defmodule Rclex.Subscription do
        name: name,
        namespace: namespace,
        subscription: subscription,
-       callback_resource: callback_resource
-     }}
+       callback_resource: nil
+     }, {:continue, nil}}
   end
 
-  def terminate(reason, state) do
-    if System.fetch_env!("ROS_DISTRO") == "foxy" do
-      Nif.rcl_wait_set_fini!(state.callback_resource)
-    else
-      Nif.rcl_subscription_clear_message_callback!(state.subscription, state.callback_resource)
-    end
+  case System.fetch_env!("ROS_DISTRO") do
+    "foxy" ->
+      def terminate(reason, state) do
+        Nif.rcl_wait_set_fini!(state.callback_resource)
+        Nif.rcl_subscription_fini!(state.subscription, state.node)
 
-    Nif.rcl_subscription_fini!(state.subscription, state.node)
-
-    Logger.debug("#{__MODULE__}: #{inspect(reason)} #{Path.join(state.namespace, state.name)}")
-  end
-
-  def handle_info(:take, state) do
-    case Nif.rcl_wait_subscription!(state.callback_resource, 1000, state.subscription) do
-      :ok ->
-        message = apply(state.message_type, :create!, [])
-
-        try do
-          case Nif.rcl_take!(state.subscription, message) do
-            :ok ->
-              message_struct = apply(state.message_type, :get!, [message])
-
-              {:ok, _pid} =
-                Task.Supervisor.start_child(
-                  {:via, PartitionSupervisor, {Rclex.TaskSupervisors, self()}},
-                  fn -> state.callback.(message_struct) end
-                )
-
-            :error ->
-              Logger.error("#{__MODULE__}: take failed but no error occurred in the middleware")
-          end
-        after
-          :ok = apply(state.message_type, :destroy!, [message])
-        end
-
-      :timeout ->
-        nil
-    end
-
-    send(self(), :take)
-
-    {:noreply, state}
-  end
-
-  def handle_info({:new_message, number_of_events}, state) when number_of_events > 0 do
-    for _ <- 1..number_of_events do
-      message = apply(state.message_type, :create!, [])
-
-      try do
-        case Nif.rcl_take!(state.subscription, message) do
-          :ok ->
-            message_struct = apply(state.message_type, :get!, [message])
-
-            {:ok, _pid} =
-              Task.Supervisor.start_child(
-                {:via, PartitionSupervisor, {Rclex.TaskSupervisors, self()}},
-                fn -> state.callback.(message_struct) end
-              )
-
-          :error ->
-            Logger.error("#{__MODULE__}: take failed but no error occurred in the middleware")
-        end
-      after
-        :ok = apply(state.message_type, :destroy!, [message])
+        Logger.debug(
+          "#{__MODULE__}: #{inspect(reason)} #{Path.join(state.namespace, state.name)}"
+        )
       end
-    end
 
-    {:noreply, state}
+      def handle_continue(nil, state) do
+        send(self(), :take)
+        callback_resource = Nif.rcl_wait_set_init_subscription!(state.context)
+        {:noreply, %{state | callback_resource: callback_resource}}
+      end
+
+      def handle_info(:take, state) do
+        case Nif.rcl_wait_subscription!(state.callback_resource, 1000, state.subscription) do
+          :ok ->
+            message = apply(state.message_type, :create!, [])
+
+            try do
+              case Nif.rcl_take!(state.subscription, message) do
+                :ok ->
+                  message_struct = apply(state.message_type, :get!, [message])
+
+                  {:ok, _pid} =
+                    Task.Supervisor.start_child(
+                      {:via, PartitionSupervisor, {Rclex.TaskSupervisors, self()}},
+                      fn -> state.callback.(message_struct) end
+                    )
+
+                :error ->
+                  Logger.error(
+                    "#{__MODULE__}: take failed but no error occurred in the middleware"
+                  )
+              end
+            after
+              :ok = apply(state.message_type, :destroy!, [message])
+            end
+
+          :timeout ->
+            nil
+        end
+
+        send(self(), :take)
+
+        {:noreply, state}
+      end
+
+    _ ->
+      def terminate(reason, state) do
+        Nif.rcl_subscription_clear_message_callback!(state.subscription, state.callback_resource)
+        Nif.rcl_subscription_fini!(state.subscription, state.node)
+
+        Logger.debug(
+          "#{__MODULE__}: #{inspect(reason)} #{Path.join(state.namespace, state.name)}"
+        )
+      end
+
+      def handle_continue(nil, state) do
+        callback_resource = Nif.rcl_subscription_set_on_new_message_callback!(state.subscription)
+        {:noreply, %{state | callback_resource: callback_resource}}
+      end
+
+      def handle_info({:new_message, number_of_events}, state) when number_of_events > 0 do
+        for _ <- 1..number_of_events do
+          message = apply(state.message_type, :create!, [])
+
+          try do
+            case Nif.rcl_take!(state.subscription, message) do
+              :ok ->
+                message_struct = apply(state.message_type, :get!, [message])
+
+                {:ok, _pid} =
+                  Task.Supervisor.start_child(
+                    {:via, PartitionSupervisor, {Rclex.TaskSupervisors, self()}},
+                    fn -> state.callback.(message_struct) end
+                  )
+
+              :error ->
+                Logger.error("#{__MODULE__}: take failed but no error occurred in the middleware")
+            end
+          after
+            :ok = apply(state.message_type, :destroy!, [message])
+          end
+        end
+
+        {:noreply, state}
+      end
   end
 end

--- a/src/nif_funcs.c
+++ b/src/nif_funcs.c
@@ -39,6 +39,10 @@ static ErlNifFunc nif_funcs[] = {
     nif_io_bound_func(rcl_publish, 2),
     nif_io_bound_func(rcl_subscription_init, 4),
     nif_io_bound_func(rcl_subscription_fini, 2),
+#ifndef ROS_DISTRO_foxy
+    nif_regular_func(rcl_subscription_set_on_new_message_callback, 1),
+    nif_regular_func(rcl_subscription_clear_message_callback, 2),
+#endif
     nif_io_bound_func(rcl_take, 2),
     nif_io_bound_func(rcl_clock_init, 0),
     nif_io_bound_func(rcl_clock_fini, 1),
@@ -67,6 +71,7 @@ static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info) {
 
   make_common_atoms(env);
   make_qos_atoms(env);
+  make_subscription_atom(env);
   if (open_resource_types(env, "Elixir.Rclex.Nif") != 0) return 1;
 
   return 0;

--- a/src/rcl_subscription.c
+++ b/src/rcl_subscription.c
@@ -123,7 +123,8 @@ ERL_NIF_TERM nif_rcl_subscription_set_on_new_message_callback(ErlNifEnv *env, in
     return enif_make_badarg(env);
   if (!rcl_subscription_is_valid(subscription_p)) return raise(env, __FILE__, __LINE__);
 
-  ErlNifPid *pid_p = (ErlNifPid *)enif_alloc_resource(rt_callback_resource, sizeof(ErlNifPid));
+  ErlNifPid *pid_p =
+      (ErlNifPid *)enif_alloc_resource(rt_subscription_callback_resource, sizeof(ErlNifPid));
   if (enif_self(env, pid_p) == NULL) return raise(env, __FILE__, __LINE__);
   enif_keep_resource(pid_p);
 
@@ -145,7 +146,7 @@ ERL_NIF_TERM nif_rcl_subscription_clear_message_callback(ErlNifEnv *env, int arg
   if (!rcl_subscription_is_valid(subscription_p)) return raise(env, __FILE__, __LINE__);
 
   ErlNifPid *pid_p = NULL;
-  if (!enif_get_resource(env, argv[1], rt_callback_resource, (void **)&pid_p))
+  if (!enif_get_resource(env, argv[1], rt_subscription_callback_resource, (void **)&pid_p))
     return enif_make_badarg(env);
 
   rcl_ret_t rc;

--- a/src/rcl_subscription.h
+++ b/src/rcl_subscription.h
@@ -1,5 +1,11 @@
 #include <erl_nif.h>
 
+extern void make_subscription_atom(ErlNifEnv *env);
+
 ERL_NIF_TERM nif_rcl_subscription_init(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM nif_rcl_subscription_fini(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM nif_rcl_take(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM nif_rcl_subscription_set_on_new_message_callback(ErlNifEnv *env, int argc,
+                                                              const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM nif_rcl_subscription_clear_message_callback(ErlNifEnv *env, int argc,
+                                                         const ERL_NIF_TERM argv[]);

--- a/src/rcl_wait.c
+++ b/src/rcl_wait.c
@@ -85,8 +85,8 @@ ERL_NIF_TERM nif_rcl_wait_subscription(ErlNifEnv *env, int argc, const ERL_NIF_T
 
   int timeout_us;
   if (!enif_get_int(env, argv[1], &timeout_us)) return enif_make_badarg(env);
-  if (timeout_us > 1000)
-    return raise_with_message(env, __FILE__, __LINE__, "1000us over is too long for nif.");
+  if (timeout_us > 1024)
+    return raise_with_message(env, __FILE__, __LINE__, "1024us over is too long for nif.");
 
   rcl_subscription_t *subscription_p;
   if (!enif_get_resource(env, argv[2], rt_rcl_subscription_t, (void **)&subscription_p))

--- a/src/rcl_wait.c
+++ b/src/rcl_wait.c
@@ -85,8 +85,8 @@ ERL_NIF_TERM nif_rcl_wait_subscription(ErlNifEnv *env, int argc, const ERL_NIF_T
 
   int timeout_us;
   if (!enif_get_int(env, argv[1], &timeout_us)) return enif_make_badarg(env);
-  if (timeout_us > 1024)
-    return raise_with_message(env, __FILE__, __LINE__, "1024us over is too long for nif.");
+  if (timeout_us > 1000)
+    return raise_with_message(env, __FILE__, __LINE__, "1000us over is too long for nif.");
 
   rcl_subscription_t *subscription_p;
   if (!enif_get_resource(env, argv[2], rt_rcl_subscription_t, (void **)&subscription_p))

--- a/src/resource_types.c
+++ b/src/resource_types.c
@@ -11,7 +11,7 @@ ErlNifResourceType *rt_rcl_timer_t;
 ErlNifResourceType *rt_rcl_wait_set_t;
 ErlNifResourceType *rt_rosidl_message_type_support_t;
 ErlNifResourceType *rt_ros_message;
-ErlNifResourceType *rt_callback_resource;
+ErlNifResourceType *rt_subscription_callback_resource;
 
 #define open_rt_return_if_error(env, module, name, flags)                                          \
   rt_##name = enif_open_resource_type(env, module, #name, NULL, flags, NULL);                      \
@@ -29,7 +29,7 @@ int open_resource_types(ErlNifEnv *env, const char *module) {
   open_rt_return_if_error(env, module, rcl_wait_set_t, flags);
   open_rt_return_if_error(env, module, rosidl_message_type_support_t, flags);
   open_rt_return_if_error(env, module, ros_message, flags);
-  open_rt_return_if_error(env, module, callback_resource, flags);
+  open_rt_return_if_error(env, module, subscription_callback_resource, flags);
 
   return 0;
 }

--- a/src/resource_types.c
+++ b/src/resource_types.c
@@ -11,6 +11,7 @@ ErlNifResourceType *rt_rcl_timer_t;
 ErlNifResourceType *rt_rcl_wait_set_t;
 ErlNifResourceType *rt_rosidl_message_type_support_t;
 ErlNifResourceType *rt_ros_message;
+ErlNifResourceType *rt_callback_resource;
 
 #define open_rt_return_if_error(env, module, name, flags)                                          \
   rt_##name = enif_open_resource_type(env, module, #name, NULL, flags, NULL);                      \
@@ -28,6 +29,7 @@ int open_resource_types(ErlNifEnv *env, const char *module) {
   open_rt_return_if_error(env, module, rcl_wait_set_t, flags);
   open_rt_return_if_error(env, module, rosidl_message_type_support_t, flags);
   open_rt_return_if_error(env, module, ros_message, flags);
+  open_rt_return_if_error(env, module, callback_resource, flags);
 
   return 0;
 }

--- a/src/resource_types.h
+++ b/src/resource_types.h
@@ -9,5 +9,6 @@ extern ErlNifResourceType *rt_rcl_timer_t;
 extern ErlNifResourceType *rt_rcl_wait_set_t;
 extern ErlNifResourceType *rt_rosidl_message_type_support_t;
 extern ErlNifResourceType *rt_ros_message;
+extern ErlNifResourceType *rt_callback_resource;
 
 extern int open_resource_types(ErlNifEnv *env, const char *module);

--- a/src/resource_types.h
+++ b/src/resource_types.h
@@ -9,6 +9,6 @@ extern ErlNifResourceType *rt_rcl_timer_t;
 extern ErlNifResourceType *rt_rcl_wait_set_t;
 extern ErlNifResourceType *rt_rosidl_message_type_support_t;
 extern ErlNifResourceType *rt_ros_message;
-extern ErlNifResourceType *rt_callback_resource;
+extern ErlNifResourceType *rt_subscription_callback_resource;
 
 extern int open_resource_types(ErlNifEnv *env, const char *module);

--- a/test/rclex/nif_test.exs
+++ b/test/rclex/nif_test.exs
@@ -345,6 +345,29 @@ defmodule Rclex.NifTest do
         Nif.rcl_subscription_init!(node, type_support, ~c"topic", qos)
       end
     end
+
+    if System.fetch_env!("ROS_DISTRO") != "foxy" do
+      test "rcl_subscription_set_on_new_message_callback!/1", %{
+        node: node,
+        type_support: type_support,
+        qos: qos
+      } do
+        subscription = Nif.rcl_subscription_init!(node, type_support, ~c"/topic", qos)
+        assert is_reference(Nif.rcl_subscription_set_on_new_message_callback!(subscription))
+      end
+
+      test "rcl_subscription_clear_message_callback!/2", %{
+        node: node,
+        type_support: type_support,
+        qos: qos
+      } do
+        subscription = Nif.rcl_subscription_init!(node, type_support, ~c"/topic", qos)
+        callback_resource = Nif.rcl_subscription_set_on_new_message_callback!(subscription)
+
+        assert Nif.rcl_subscription_clear_message_callback!(subscription, callback_resource) ==
+                 :ok
+      end
+    end
   end
 
   describe "wait_set" do

--- a/test/rclex/nif_test.exs
+++ b/test/rclex/nif_test.exs
@@ -347,25 +347,21 @@ defmodule Rclex.NifTest do
     end
 
     if System.fetch_env!("ROS_DISTRO") != "foxy" do
-      test "rcl_subscription_set_on_new_message_callback!/1", %{
-        node: node,
-        type_support: type_support,
-        qos: qos
-      } do
-        subscription = Nif.rcl_subscription_init!(node, type_support, ~c"/topic", qos)
-        assert is_reference(Nif.rcl_subscription_set_on_new_message_callback!(subscription))
-      end
-
-      test "rcl_subscription_clear_message_callback!/2", %{
-        node: node,
-        type_support: type_support,
-        qos: qos
-      } do
+      test "rcl_subscription_set_on_new_message_callback!/1, rcl_subscription_clear_message_callback!/2",
+           %{
+             node: node,
+             type_support: type_support,
+             qos: qos
+           } do
         subscription = Nif.rcl_subscription_init!(node, type_support, ~c"/topic", qos)
         callback_resource = Nif.rcl_subscription_set_on_new_message_callback!(subscription)
 
+        assert is_reference(callback_resource)
+
         assert Nif.rcl_subscription_clear_message_callback!(subscription, callback_resource) ==
                  :ok
+
+        :ok = Nif.rcl_subscription_fini!(subscription, node)
       end
     end
   end


### PR DESCRIPTION
This is a just idea to change subscription's timeout dynamically.

### 目的

メッセージが飛んでくる時間的な頻度に応じ、動的に `timeout [us]` を変えることで応答を良くすることを目的とする。

### 効果の検証

1000us 固定でも、 message が届いていればすぐ返るのだから、本修正は不要に考えられるが timeout を変更することで応答がよくなるという傾向が見られている。

1000us 固定の場合に複数の subscription GenServer がある場合に遅くなる傾向があるので、各 Erlang プロセスへの ERTS のスケジューラーのリソース配分が影響しているのかもしれない。が、憶測にすぎない。この辺を突き止めて改善できるとよい。

