### PR TITLE
release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## v0.11.1 on 03 Oct 2024
+
+**Full Changelog**: https://github.com/rclex/rclex/compare/v0.11.0...v0.11.1
+
+* New features: none
+* Code Improvements/Fixes:
+  * Fix UnicodeConversionError caused by treating a uint8 array as Unicode by @pojiro in https://github.com/rclex/rclex/pull/345
+* Bumps:
+  * Bump dialyxir from 1.4.3 to 1.4.4 by @dependabot in https://github.com/rclex/rclex/pull/343
+  * Bump credo from 1.7.7 to 1.7.8 by @dependabot in https://github.com/rclex/rclex/pull/342
+  * Bump ex_doc from 0.34.1 to 0.34.2 by @dependabot in https://github.com/rclex/rclex/pull/335
+* Note in this release:
+  * We deeply apologize,,, v0.11.0 could not be released on hex.pm because API key had revoked for GHA,,,
+
 ## v0.11.0 on 07 Jul 2024
 
 **Full Changelog**: https://github.com/rclex/rclex/compare/v0.10.1...v0.11.0

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
   defp deps do
     [
       ...
-      {:rclex, "~> 0.11.0"},
+      {:rclex, "~> 0.11.1"},
       ...
     ]
   end

--- a/README_ja.md
+++ b/README_ja.md
@@ -89,7 +89,7 @@ cd rclex_usage
   defp deps do
     [
       ...
-      {:rclex, "~> 0.11.0"},
+      {:rclex, "~> 0.11.1"},
       ...
     ]
   end

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -67,7 +67,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
   defp deps do
     [
       ...
-      {:rclex, "~> 0.11.0"},
+      {:rclex, "~> 0.11.1"},
       ...
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Rclex.MixProject do
   """
 
   @app :rclex
-  @version "0.11.0"
+  @version "0.11.1"
   @source_url "https://github.com/rclex/rclex"
 
   def project do


### PR DESCRIPTION
**Full Changelog**: https://github.com/rclex/rclex/compare/v0.11.0...v0.11.1

* New features: none
* Code Improvements/Fixes:
  * Fix UnicodeConversionError caused by treating a uint8 array as Unicode by @pojiro in https://github.com/rclex/rclex/pull/345
* Bumps:
  * Bump dialyxir from 1.4.3 to 1.4.4 by @dependabot in https://github.com/rclex/rclex/pull/343
  * Bump credo from 1.7.7 to 1.7.8 by @dependabot in https://github.com/rclex/rclex/pull/342
  * Bump ex_doc from 0.34.1 to 0.34.2 by @dependabot in https://github.com/rclex/rclex/pull/335
* Note in this release:
  * We deeply apologize,,, v0.11.0 could not be released on hex.pm because API key had revoked for GHA,,,