### PR TITLE
Optimize binary copy for ROS2 rcl uint8 array

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,7 @@ config :rclex,
     "std_msgs/msg/UInt8MultiArray",
     "std_msgs/msg/UInt32MultiArray",
     "geometry_msgs/msg/Twist",
+    "sensor_msgs/msg/Image",
     "sensor_msgs/msg/PointCloud",
     "diagnostic_msgs/msg/DiagnosticStatus",
     "action_msgs/msg/GoalInfo"

--- a/lib/mix/tasks/rclex/gen/msgs.ex
+++ b/lib/mix/tasks/rclex/gen/msgs.ex
@@ -157,12 +157,15 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
     Enum.map_join(types, fn {:msg_type, type} ->
       function_prefix = Util.type_down_snake(type)
 
+      # WHY: Use ERL_NIF_DIRTY_JOB_IO_BOUND for destroy!, set!, and get!
+      #      These functions (de)allocate memory, and the size depends on the payload.
+      #      Therefore, the time required for the operations is unpredictable.
       """
       {"#{function_prefix}_type_support!", 0, nif_#{function_prefix}_type_support, REGULAR_NIF},
       {"#{function_prefix}_create!", 0, nif_#{function_prefix}_create, REGULAR_NIF},
-      {"#{function_prefix}_destroy!", 1, nif_#{function_prefix}_destroy, REGULAR_NIF},
-      {"#{function_prefix}_set!", 2, nif_#{function_prefix}_set, REGULAR_NIF},
-      {"#{function_prefix}_get!", 1, nif_#{function_prefix}_get, REGULAR_NIF},
+      {"#{function_prefix}_destroy!", 1, nif_#{function_prefix}_destroy, ERL_NIF_DIRTY_JOB_IO_BOUND},
+      {"#{function_prefix}_set!", 2, nif_#{function_prefix}_set, ERL_NIF_DIRTY_JOB_IO_BOUND},
+      {"#{function_prefix}_get!", 1, nif_#{function_prefix}_get, ERL_NIF_DIRTY_JOB_IO_BOUND},
       """
     end)
   end

--- a/lib/rclex/generators/msg_ex.ex
+++ b/lib/rclex/generators/msg_ex.ex
@@ -144,7 +144,7 @@ defmodule Rclex.Generators.MsgEx do
             "#{name}"
 
           [{:builtin_type_array, "uint8[" <> _}, name] ->
-            "#{name} |> :binary.bin_to_list()"
+            "#{name}"
 
           [{:builtin_type_array, _type}, name] ->
             "#{name}"
@@ -187,7 +187,7 @@ defmodule Rclex.Generators.MsgEx do
             "#{name}: #{name}"
 
           [{:builtin_type_array, "uint8[" <> _}, name] ->
-            "#{name}: #{name} |> IO.iodata_to_binary()"
+            "#{name}: #{name}"
 
           [{:builtin_type_array, _type}, name] ->
             "#{name}: #{name}"

--- a/mix.exs
+++ b/mix.exs
@@ -133,6 +133,10 @@ defmodule Rclex.MixProject do
 
   defp test_coverage() do
     [
+      summary: [
+        # Remove when https://github.com/rclex/rclex/issues/349 is resolved.
+        threshold: 80
+      ],
       ignore_modules: [
         Rclex.Nif,
         Rclex.Generators.MsgC.Acc,

--- a/scripts/sensor_msgs_msg_image_benchee.exs
+++ b/scripts/sensor_msgs_msg_image_benchee.exs
@@ -5,12 +5,12 @@ struct = %Rclex.Pkgs.SensorMsgs.Msg.Image{
     stamp: %Rclex.Pkgs.BuiltinInterfaces.Msg.Time{sec: 872_037, nanosec: 631_914},
     frame_id: "image"
   },
-  height: 240,
-  width: 320,
-  encoding: "8UC1",
+  height: 480,
+  width: 640,
+  encoding: "8UC3",
   is_bigendian: 0,
-  step: 320 * 1,
-  data: for(_ <- 1..(240 * 320 * 1), into: <<>>, do: <<:rand.uniform(256) - 1>>)
+  step: 640 * 3,
+  data: for(_ <- 1..(480 * 640 * 3), into: <<>>, do: <<:rand.uniform(256) - 1>>)
 }
 
 Benchee.run(%{

--- a/scripts/sensor_msgs_msg_image_benchee.exs
+++ b/scripts/sensor_msgs_msg_image_benchee.exs
@@ -1,0 +1,59 @@
+alias Rclex.Pkgs.SensorMsgs
+
+struct = %Rclex.Pkgs.SensorMsgs.Msg.Image{
+  header: %Rclex.Pkgs.StdMsgs.Msg.Header{
+    stamp: %Rclex.Pkgs.BuiltinInterfaces.Msg.Time{sec: 872_037, nanosec: 631_914},
+    frame_id: "image"
+  },
+  height: 240,
+  width: 320,
+  encoding: "8UC1",
+  is_bigendian: 0,
+  step: 320 * 1,
+  data: for(_ <- 1..(240 * 320 * 1), into: <<>>, do: <<:rand.uniform(256) - 1>>)
+}
+
+Benchee.run(%{
+  "create!/0" => {
+    fn ->
+      SensorMsgs.Msg.Image.create!()
+    end,
+    after_each: fn message ->
+      SensorMsgs.Msg.Image.destroy!(message)
+    end
+  },
+  "set!/2" => {
+    fn message ->
+      SensorMsgs.Msg.Image.set!(message, struct)
+      message
+    end,
+    before_each: fn _ ->
+      SensorMsgs.Msg.Image.create!()
+    end,
+    after_each: fn message ->
+      SensorMsgs.Msg.Image.destroy!(message)
+    end
+  },
+  "get!/1" => {
+    fn message ->
+      SensorMsgs.Msg.Image.get!(message)
+      message
+    end,
+    before_each: fn _ ->
+      message = SensorMsgs.Msg.Image.create!()
+      SensorMsgs.Msg.Image.set!(message, struct)
+      message
+    end,
+    after_each: fn message ->
+      SensorMsgs.Msg.Image.destroy!(message)
+    end
+  },
+  "destroy!/1" => {
+    fn message -> SensorMsgs.Msg.Image.destroy!(message) end,
+    before_each: fn _ ->
+      message = SensorMsgs.Msg.Image.create!()
+      SensorMsgs.Msg.Image.set!(message, struct)
+      message
+    end
+  }
+})

--- a/test/rclex/pkgs/msgs_test.exs
+++ b/test/rclex/pkgs/msgs_test.exs
@@ -112,6 +112,26 @@ defmodule Rclex.Pkgs.MsgsTest do
     |> tap(&Rclex.Pkgs.SensorMsgs.Msg.PointCloud.destroy!(&1))
   end
 
+  test "sensor_msgs/msg/Image" do
+    struct = %Rclex.Pkgs.SensorMsgs.Msg.Image{
+      header: %Rclex.Pkgs.StdMsgs.Msg.Header{
+        stamp: %Rclex.Pkgs.BuiltinInterfaces.Msg.Time{sec: 872_037, nanosec: 631_914},
+        frame_id: "image"
+      },
+      height: 480,
+      width: 640,
+      encoding: "8UC3",
+      is_bigendian: 0,
+      step: 640 * 3,
+      data: for(_ <- 1..(480 * 640 * 3), into: <<>>, do: <<:rand.uniform(256) - 1>>)
+    }
+
+    Rclex.Pkgs.SensorMsgs.Msg.Image.create!()
+    |> tap(&Rclex.Pkgs.SensorMsgs.Msg.Image.set!(&1, struct))
+    |> tap(fn message -> assert ^struct = Rclex.Pkgs.SensorMsgs.Msg.Image.get!(message) end)
+    |> tap(&Rclex.Pkgs.SensorMsgs.Msg.Image.destroy!(&1))
+  end
+
   test "diagnostic_msgs/msg/DiagnosticStatus" do
     struct = %Rclex.Pkgs.DiagnosticMsgs.Msg.DiagnosticStatus{
       level: 3,


### PR DESCRIPTION
- Replaced individual uint8 list copying with `memcpy` to avoid segmentation fault when handling large ERL_NIF_TERM arrays.
- This change also improves performance of the copy process.

This PR will close #347 .

---

TODO left

- [x] add comment, なぜ uint8 array を別扱いにするのか、 struct copy等
- [x] add bench
- [x] check test coverage
    - this should be fixed by #349 

---

## bench result

Before fix, it causes segmentation fault(#347), so I need to shrink the test image size like following. 
This bench uses this data as example image.

```elixir
%Rclex.Pkgs.SensorMsgs.Msg.Image{
  header: %Rclex.Pkgs.StdMsgs.Msg.Header{
    stamp: %Rclex.Pkgs.BuiltinInterfaces.Msg.Time{sec: 872_037, nanosec: 631_914},
    frame_id: "image"
  },
  height: 240,
  width: 320,
  encoding: "8UC1",
  is_bigendian: 0,
  step: 320 * 1,
  data: for(_ <- 1..(240 * 320 * 1), into: <<>>, do: <<:rand.uniform(256) - 1>>)
}
```

### before fix result (240 x 320 x 1)

```bash
mix run scripts/sensor_msgs_msg_image_benchee.exs
...
Name                 ips        average  deviation         median         99th %
create!/0         1.59 M        0.63 μs  ±7499.52%       0.179 μs        0.39 μs
destroy!/1        1.38 M        0.73 μs    ±98.33%        0.58 μs        2.20 μs
set!/2         0.00179 M      558.90 μs    ±37.47%      528.74 μs      898.12 μs
get!/1         0.00139 M      719.94 μs    ±16.27%      687.00 μs     1146.41 μs

Comparison: 
create!/0         1.59 M
destroy!/1        1.38 M - 1.15x slower +0.0958 μs
set!/2         0.00179 M - 886.86x slower +558.27 μs
get!/1         0.00139 M - 1142.38x slower +719.31 μs
```

### after fix result (240 x 320 x 1)

```bash
mix run scripts/sensor_msgs_msg_image_benchee.exs
...
Name                 ips        average  deviation         median         99th %
create!/0      1248.18 K        0.80 μs  ±5242.91%        0.31 μs        0.85 μs
destroy!/1      732.91 K        1.36 μs    ±39.05%        1.35 μs        2.16 μs
get!/1          236.84 K        4.22 μs   ±201.79%        3.96 μs        8.05 μs
set!/2          154.30 K        6.48 μs   ±701.11%        5.72 μs        8.71 μs

Comparison: 
create!/0      1248.18 K
destroy!/1      732.91 K - 1.70x slower +0.56 μs
get!/1          236.84 K - 5.27x slower +3.42 μs
set!/2          154.30 K - 8.09x slower +5.68 μs
```

### after fix result (480 x 640 x 3)

This bench uses a bigger image, (480 x 640 x 3).

```bash
mix run scripts/sensor_msgs_msg_image_benchee.exs
...
Name                 ips        average  deviation         median         99th %
create!/0      1329.89 K        0.75 μs  ±4950.56%        0.28 μs        0.92 μs
destroy!/1       42.81 K       23.36 μs    ±49.79%       21.69 μs       77.85 μs
get!/1           20.40 K       49.02 μs    ±32.07%       44.77 μs       98.30 μs
set!/2            4.64 K      215.59 μs    ±13.07%      208.50 μs      310.48 μs

Comparison: 
create!/0      1329.89 K
destroy!/1       42.81 K - 31.06x slower +22.61 μs
get!/1           20.40 K - 65.19x slower +48.27 μs
set!/2            4.64 K - 286.71x slower +214.84 μs
```