### PR TITLE
Bump supported versions and CI targets

### DIFF
--- a/.github/workflows/ci-all_version.yml
+++ b/.github/workflows/ci-all_version.yml
@@ -14,13 +14,12 @@ jobs:
       matrix:
         dockertags: [
           latest,
-          jazzy-ex1.17.3-otp27.2,
-          # WHY commented out: see https://github.com/rclex/rclex/issues/228#issuecomment-1715288806
-          #iron-ex1.15.5-otp26.0.2,
-          humble-ex1.16.2-otp26.2.2,
-          humble-ex1.15.7-otp26.2.2,
-          humble-ex1.14.5-otp25.3.2.5,
-          foxy-ex1.15.5-otp26.0.2,
+          jazzy-ex1.18.2-otp27.2.4,
+          jazzy-ex1.17.3-otp27.2.4,
+          jazzy-ex1.16.3-otp26.2.5,
+          humble-ex1.18.2-otp27.2.4,
+          humble-ex1.17.3-otp27.2.4,
+          humble-ex1.16.3-otp26.2.5,
         ]
     container: rclex/rclex_docker:${{ matrix.dockertags }}
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 26.2.2
-elixir 1.15.7-otp-26
+erlang 27.2.4
+elixir 1.17.3-otp-27

--- a/README.md
+++ b/README.md
@@ -38,14 +38,13 @@ The basic and recommended environment is where the host (development) and the ta
 
 Currently, we use the following environment as the main development target:
 
-- Ubuntu 22.04.4 LTS (Jammy Jellyfish)
-- ROS 2 [Humble Hawksbill](https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html)
-- Elixir 1.15.7-otp-26
-- Erlang/OTP 26.2.2
+- Ubuntu 22.04 LTS (Jammy Jellyfish)
+- ROS 2 Humble Hawksbill
+- Elixir 1.17.3-otp-27
+- Erlang/OTP 27.2.4
 
-We highly recommend using Humble for ROS 2 LTS distribution.
-Iron, the STS distribution, is experimentally supported and confirmed for the proper operation only in the native environment. See detail and status on [Issue#228](https://github.com/rclex/rclex/issues/228#issuecomment-1715293177).
-Although we also use Foxy and Galactic as CI targets, they have already reached EOL.
+We highly recommend using [Humble Hawksbill](https://docs.ros.org/en/rolling/Releases/Release-Humble-Hawksbill.html) for ROS 2 LTS distribution.
+We also confirmed the operation of this library with [Jazzy Jalisco](https://docs.ros.org/en/rolling/Releases/Release-Jazzy-Jalisco.html). See details in [PR#361](https://github.com/rclex/rclex/pull/361).  
 
 For other environments used to check the operation of this library,
 please refer to [here](https://github.com/rclex/rclex_docker#available-versions-docker-tags).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Currently, we use the following environment as the main development target:
 - Erlang/OTP 27.2.4
 
 We highly recommend using [Humble Hawksbill](https://docs.ros.org/en/rolling/Releases/Release-Humble-Hawksbill.html) for ROS 2 LTS distribution.
-We also confirmed the operation of this library with [Jazzy Jalisco](https://docs.ros.org/en/rolling/Releases/Release-Jazzy-Jalisco.html). See details in [PR#361](https://github.com/rclex/rclex/pull/361).  
+We also confirmed the operation of this library with [Jazzy Jalisco](https://docs.ros.org/en/rolling/Releases/Release-Jazzy-Jalisco.html) on Ubuntu 24.04 LTS. See details in [PR#361](https://github.com/rclex/rclex/pull/361).  
 
 For other environments used to check the operation of this library,
 please refer to [here](https://github.com/rclex/rclex_docker#available-versions-docker-tags).

--- a/README_ja.md
+++ b/README_ja.md
@@ -40,7 +40,7 @@ ROS 2の主な貢献として，通信にDDS（Data Distribution Service）プ�
 - Erlang/OTP 27.2.4
 
 ROS 2には長期サポート版（LTS）である[Humble Hawksbill](https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html)の利用を強く推奨します．
-[Jazzy Jalisco](https://docs.ros.org/en/rolling/Releases/Release-Jazzy-Jalisco.html)での動作確認も行っています．詳細は[PR#361](https://github.com/rclex/rclex/pull/361)を参照ください．
+Ubuntu 24.04 LTS上での[Jazzy Jalisco](https://docs.ros.org/en/rolling/Releases/Release-Jazzy-Jalisco.html)との本ライブラリの動作確認も行っています．詳細は[PR#361](https://github.com/rclex/rclex/pull/361)を参照ください．
 
 短期サポート版（STS）のIronは，実験的なサポートでありネイティブ環境での基本的な動作のみを確認しています．対応状況の詳細は[Issue#228](https://github.com/rclex/rclex/issues/228#issuecomment-1715293177)を確認してください．
 FoxyとGalacticもCI対象としていますが，これらはすでにEOLとなっています．

--- a/README_ja.md
+++ b/README_ja.md
@@ -34,12 +34,14 @@ ROS 2の主な貢献として，通信にDDS（Data Distribution Service）プ�
 
 現在，下記の環境を主な対象として開発を進めています．
 
-- Ubuntu 22.04.4 LTS (Jammy Jellyfish)
-- ROS 2 [Humble Hawksbill](https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html)
-- Elixir 1.15.7-otp-26
-- Erlang/OTP 26.2.2
+- Ubuntu 22.04 LTS (Jammy Jellyfish)
+- ROS 2 Humble Hawksbill
+- Elixir 1.17.3-otp-27
+- Erlang/OTP 27.2.4
 
-ROS 2には長期サポート版（LTS）であるHumbleの利用を強く推奨します．
+ROS 2には長期サポート版（LTS）である[Humble Hawksbill](https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html)の利用を強く推奨します．
+[Jazzy Jalisco](https://docs.ros.org/en/rolling/Releases/Release-Jazzy-Jalisco.html)での動作確認も行っています．詳細は[PR#361](https://github.com/rclex/rclex/pull/361)を参照ください．
+
 短期サポート版（STS）のIronは，実験的なサポートでありネイティブ環境での基本的な動作のみを確認しています．対応状況の詳細は[Issue#228](https://github.com/rclex/rclex/issues/228#issuecomment-1715293177)を確認してください．
 FoxyとGalacticもCI対象としていますが，これらはすでにEOLとなっています．
 

--- a/scripts/iwyu.sh
+++ b/scripts/iwyu.sh
@@ -3,7 +3,7 @@
 # find src -name "*.c" -exec ./iwyu.sh {} \;
 
 include-what-you-use \
--I"$HOME/.asdf/installs/erlang/26.0.2/usr/include" \
+-I"$HOME/.asdf/installs/erlang/27.2.4/usr/include" \
 -I"/opt/ros/$ROS_DISTRO/include/rcl" \
 -I"/opt/ros/$ROS_DISTRO/include/rcutils" \
 -I"/opt/ros/$ROS_DISTRO/include/rmw" \


### PR DESCRIPTION
Relate: 
https://github.com/rclex/rclex_docker/pull/20

This PR tries to bump versions for our support and CI targets in `ci-all_version.yml`.
First, we will check the operation on GitHub Actions. Also, we plan to remove Foxy-dependent code and do other work before merging.