### PR TITLE
Remove old distro's dependent code that has already reached EOL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,6 @@ ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR) -lei
 ifeq ($(ROS_DISTRO), humble)
 ROS_INCS    ?= rcl rcutils rmw rcl_yaml_param_parser rosidl_runtime_c rosidl_typesupport_interface
 ROS_CFLAGS  ?= $(addprefix -I$(ROS_DIR)/include/, $(ROS_INCS))
-else ifeq ($(ROS_DISTRO), iron)
-ROS_INCS    ?= rcl rcutils rmw rcl_yaml_param_parser type_description_interfaces rosidl_runtime_c service_msgs builtin_interfaces rosidl_typesupport_interface rosidl_dynamic_typesupport
-ROS_CFLAGS  ?= $(addprefix -I$(ROS_DIR)/include/, $(ROS_INCS))
 else ifeq ($(ROS_DISTRO), jazzy)
 ROS_INCS    ?= rcl rcutils rmw rcl_yaml_param_parser type_description_interfaces rosidl_runtime_c service_msgs builtin_interfaces rosidl_typesupport_interface rosidl_dynamic_typesupport
 ROS_CFLAGS  ?= $(addprefix -I$(ROS_DIR)/include/, $(ROS_INCS))
@@ -50,8 +47,6 @@ MSG_PKGS     = $(patsubst src/pkgs/%/msg, %, $(wildcard src/pkgs/*/msg))
 SRC_C       += $(wildcard $(MSG_PKGS:%=src/pkgs/%/msg/*.c))
 MSG_OBJ_DIR  = $(MSG_PKGS:%=$(OBJ_DIR)/pkgs/%/msg)
 ifeq ($(ROS_DISTRO), humble)
-ROS_CFLAGS  += $(addprefix -I$(ROS_DIR)/include/, $(MSG_PKGS))
-else ifeq ($(ROS_DISTRO), iron)
 ROS_CFLAGS  += $(addprefix -I$(ROS_DIR)/include/, $(MSG_PKGS))
 else ifeq ($(ROS_DISTRO), jazzy)
 ROS_CFLAGS  += $(addprefix -I$(ROS_DIR)/include/, $(MSG_PKGS))

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,6 @@ ROS_CFLAGS  ?= $(addprefix -I$(ROS_DIR)/include/, $(ROS_INCS))
 else ifeq ($(ROS_DISTRO), jazzy)
 ROS_INCS    ?= rcl rcutils rmw rcl_yaml_param_parser type_description_interfaces rosidl_runtime_c service_msgs builtin_interfaces rosidl_typesupport_interface rosidl_dynamic_typesupport
 ROS_CFLAGS  ?= $(addprefix -I$(ROS_DIR)/include/, $(ROS_INCS))
-else ifeq ($(ROS_DISTRO), foxy)
-ROS_CFLAGS  ?= -I$(ROS_DIR)/include
 endif
 
 ROS_LDFLAGS ?= -L$(ROS_DIR)/lib

--- a/README.md
+++ b/README.md
@@ -45,7 +45,12 @@ Currently, we use the following environment as the main development target:
 
 We highly recommend using Humble for ROS 2 LTS distribution.
 Iron, the STS distribution, is experimentally supported and confirmed for the proper operation only in the native environment. See detail and status on [Issue#228](https://github.com/rclex/rclex/issues/228#issuecomment-1715293177).
-Although we also use Foxy and Galactic as CI targets, they have already reached EOL.
+
+We do not support ROS 2 Distributions that have already reached EOL in the development of the latest version. The last supported releases are as follows.
+
+- Foxy Fitzroy: [v0.11.3](https://github.com/rclex/rclex/releases/tag/v0.11.3)
+- Galactic Geochelone: [v0.11.3](https://github.com/rclex/rclex/releases/tag/v0.11.3)
+- Iron Irwini: [v0.11.3](https://github.com/rclex/rclex/releases/tag/v0.11.3)
 
 For other environments used to check the operation of this library,
 please refer to [here](https://github.com/rclex/rclex_docker#available-versions-docker-tags).

--- a/README_ja.md
+++ b/README_ja.md
@@ -41,7 +41,12 @@ ROS 2の主な貢献として，通信にDDS（Data Distribution Service）プ�
 
 ROS 2には長期サポート版（LTS）であるHumbleの利用を強く推奨します．
 短期サポート版（STS）のIronは，実験的なサポートでありネイティブ環境での基本的な動作のみを確認しています．対応状況の詳細は[Issue#228](https://github.com/rclex/rclex/issues/228#issuecomment-1715293177)を確認してください．
-FoxyとGalacticもCI対象としていますが，これらはすでにEOLとなっています．
+
+すでにEOLに達しているROS 2 Distributionsは，最新版に向けた開発ではサポートしていません．サポートを行っていた最終のリリース番号は次のとおりです．
+
+- Foxy Fitzroy: [v0.11.3](https://github.com/rclex/rclex/releases/tag/v0.11.3)
+- Galactic Geochelone: [v0.11.3](https://github.com/rclex/rclex/releases/tag/v0.11.3)
+- Iron Irwini: [v0.11.3](https://github.com/rclex/rclex/releases/tag/v0.11.3)
 
 動作検証の対象としている環境は[こちら](https://github.com/rclex/rclex_docker#available-versions-docker-tags)を参照してください．
 

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -24,7 +24,7 @@ The "support" colomn refers to its status of official support as the ROS 2 distr
 | `ROS_DISTRO` | arm64v8 | arm32v7 | support |
 | :--- | :--- | :---| :---|
 | humble | ○ | ○ | LTS until May 2027 |
-| galactic | ○ | - | EOL at Dec 2022 |
+| galactic | ○ | - | until [v0.11.3](https://github.com/rclex/rclex/releases/tag/v0.11.3) |
 | foxy | ○ | ○ | until [v0.11.3](https://github.com/rclex/rclex/releases/tag/v0.11.3) |
 
 ## Preliminaries
@@ -148,15 +148,6 @@ Add LD_LIBRARY_PATH line like following.
 >
 > - https://github.com/ros-tooling/cross_compile/issues/363
 > - https://github.com/ros2/rcpputils/pull/122
-
-> #### Note {: .warning }
->
-> If you want to use `galactic`, adding line should be as the below.
-> 
-> ```
-> ## only galactic needs /opt/ros/galactic/lib/aarch64-linux-gnu also, for libddsc
-> # -e LD_LIBRARY_PATH=/opt/ros/galactic/lib/aarch64-linux-gnu:/opt/ros/galactic/lib
-> ```
 
 ### Write Rclex code
 

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -25,7 +25,7 @@ The "support" colomn refers to its status of official support as the ROS 2 distr
 | :--- | :--- | :---| :---|
 | humble | ○ | ○ | LTS until May 2027 |
 | galactic | ○ | - | EOL at Dec 2022 |
-| foxy | ○ | ○ | EOL at Jun 2023 |
+| foxy | ○ | ○ | until [v0.11.3](https://github.com/rclex/rclex/releases/tag/v0.11.3) |
 
 ## Preliminaries
 
@@ -84,7 +84,7 @@ mix deps.get
 > #### Note {: .info }
 >
 > In the following steps, Humble Hawksbill (`humble`) is assumed to be used as `ROS_DISTRO` (strongly recommend to use).
-> If you want to use `foxy` or `galactic`, you need to replace it appropriately in the subsequent steps. Note that these have already reached EOL.
+> If you want to use other ROS 2 distributions, you need to replace it appropriately in the subsequent steps. Note that these have already reached EOL.
 
 The following command extracts the ROS 2 Docker image and copies resources required for Rclex to the Nerves file system.
 You may change the value of `--arch` according to the architecture of your target board (see the "arch" column on the supported target list)

--- a/lib/mix/tasks/rclex/gen/msgs.ex
+++ b/lib/mix/tasks/rclex/gen/msgs.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Rclex.Gen.Msgs do
   We can also specify explicitly as follows
 
   ```
-  mix rclex.gen.msgs --from /opt/ros/foxy/share
+  mix rclex.gen.msgs --from /opt/ros/humble/share
   ```
 
   ## How to clean

--- a/lib/mix/tasks/rclex/prep/ros2.ex
+++ b/lib/mix/tasks/rclex/prep/ros2.ex
@@ -28,9 +28,9 @@ defmodule Mix.Tasks.Rclex.Prep.Ros2 do
 
   use Mix.Task
 
-  @arm64v8_ros_distros ["foxy", "galactic", "humble"]
-  @amd64_ros_distros ["foxy", "galactic", "humble"]
-  @arm32v7_ros_distros ["foxy", "humble"]
+  @arm64v8_ros_distros ["humble"]
+  @amd64_ros_distros ["humble"]
+  @arm32v7_ros_distros ["humble"]
   @supported_ros_distros %{
     "arm64v8" => @arm64v8_ros_distros,
     "amd64" => @amd64_ros_distros,
@@ -160,15 +160,6 @@ defmodule Mix.Tasks.Rclex.Prep.Ros2 do
     [
       "/lib/#{dir_name}/libspdlog.so*",
       "/usr/lib/#{dir_name}/libacl.so*"
-    ]
-  end
-
-  defp vendor_resources(arch, "foxy") do
-    dir_name = arch_dir_name(arch)
-
-    [
-      "/lib/#{dir_name}/libspdlog.so*",
-      "/lib/#{dir_name}/libtinyxml2.so*"
     ]
   end
 

--- a/lib/mix/tasks/rclex/prep/ros2.ex
+++ b/lib/mix/tasks/rclex/prep/ros2.ex
@@ -154,15 +154,6 @@ defmodule Mix.Tasks.Rclex.Prep.Ros2 do
     ]
   end
 
-  defp vendor_resources(arch, "galactic") do
-    dir_name = arch_dir_name(arch)
-
-    [
-      "/lib/#{dir_name}/libspdlog.so*",
-      "/usr/lib/#{dir_name}/libacl.so*"
-    ]
-  end
-
   defp copy_from_docker_impl!(arch, ros_distro, src_path, dest_path) do
     with true <- File.exists?(dest_path) do
       docker_tag = ros_docker_image_tag(arch, ros_distro)

--- a/lib/rclex/subscription.ex
+++ b/lib/rclex/subscription.ex
@@ -53,96 +53,41 @@ defmodule Rclex.Subscription do
      }, {:continue, nil}}
   end
 
-  case System.fetch_env!("ROS_DISTRO") do
-    "foxy" ->
-      def terminate(reason, state) do
-        Nif.rcl_wait_set_fini!(state.callback_resource)
-        Nif.rcl_subscription_fini!(state.subscription, state.node)
+  def terminate(reason, state) do
+    Nif.rcl_subscription_clear_message_callback!(state.subscription, state.callback_resource)
+    Nif.rcl_subscription_fini!(state.subscription, state.node)
 
-        Logger.debug(
-          "#{__MODULE__}: #{inspect(reason)} #{Path.join(state.namespace, state.name)}"
-        )
-      end
+    Logger.debug("#{__MODULE__}: #{inspect(reason)} #{Path.join(state.namespace, state.name)}")
+  end
 
-      def handle_continue(nil, state) do
-        send(self(), :take)
-        callback_resource = Nif.rcl_wait_set_init_subscription!(state.context)
-        {:noreply, %{state | callback_resource: callback_resource}}
-      end
+  def handle_continue(nil, state) do
+    callback_resource = Nif.rcl_subscription_set_on_new_message_callback!(state.subscription)
+    {:noreply, %{state | callback_resource: callback_resource}}
+  end
 
-      def handle_info(:take, state) do
-        case Nif.rcl_wait_subscription!(state.callback_resource, 1000, state.subscription) do
+  def handle_info({:new_message, number_of_events}, state) when number_of_events > 0 do
+    for _ <- 1..number_of_events do
+      message = apply(state.message_type, :create!, [])
+
+      try do
+        case Nif.rcl_take!(state.subscription, message) do
           :ok ->
-            message = apply(state.message_type, :create!, [])
+            message_struct = apply(state.message_type, :get!, [message])
 
-            try do
-              case Nif.rcl_take!(state.subscription, message) do
-                :ok ->
-                  message_struct = apply(state.message_type, :get!, [message])
+            {:ok, _pid} =
+              Task.Supervisor.start_child(
+                {:via, PartitionSupervisor, {Rclex.TaskSupervisors, self()}},
+                fn -> state.callback.(message_struct) end
+              )
 
-                  {:ok, _pid} =
-                    Task.Supervisor.start_child(
-                      {:via, PartitionSupervisor, {Rclex.TaskSupervisors, self()}},
-                      fn -> state.callback.(message_struct) end
-                    )
-
-                :subscription_take_failed ->
-                  Logger.debug(
-                    "#{__MODULE__}: take failed but no error occurred in the middleware"
-                  )
-              end
-            after
-              :ok = apply(state.message_type, :destroy!, [message])
-            end
-
-          :timeout ->
-            nil
+          :subscription_take_failed ->
+            Logger.debug("#{__MODULE__}: take failed but no error occurred in the middleware")
         end
-
-        send(self(), :take)
-
-        {:noreply, state}
+      after
+        :ok = apply(state.message_type, :destroy!, [message])
       end
+    end
 
-    _ ->
-      def terminate(reason, state) do
-        Nif.rcl_subscription_clear_message_callback!(state.subscription, state.callback_resource)
-        Nif.rcl_subscription_fini!(state.subscription, state.node)
-
-        Logger.debug(
-          "#{__MODULE__}: #{inspect(reason)} #{Path.join(state.namespace, state.name)}"
-        )
-      end
-
-      def handle_continue(nil, state) do
-        callback_resource = Nif.rcl_subscription_set_on_new_message_callback!(state.subscription)
-        {:noreply, %{state | callback_resource: callback_resource}}
-      end
-
-      def handle_info({:new_message, number_of_events}, state) when number_of_events > 0 do
-        for _ <- 1..number_of_events do
-          message = apply(state.message_type, :create!, [])
-
-          try do
-            case Nif.rcl_take!(state.subscription, message) do
-              :ok ->
-                message_struct = apply(state.message_type, :get!, [message])
-
-                {:ok, _pid} =
-                  Task.Supervisor.start_child(
-                    {:via, PartitionSupervisor, {Rclex.TaskSupervisors, self()}},
-                    fn -> state.callback.(message_struct) end
-                  )
-
-              :subscription_take_failed ->
-                Logger.debug("#{__MODULE__}: take failed but no error occurred in the middleware")
-            end
-          after
-            :ok = apply(state.message_type, :destroy!, [message])
-          end
-        end
-
-        {:noreply, state}
-      end
+    {:noreply, state}
   end
 end

--- a/src/nif_funcs.c
+++ b/src/nif_funcs.c
@@ -39,10 +39,8 @@ static ErlNifFunc nif_funcs[] = {
     nif_regular_func(rcl_publish, 2),
     nif_io_bound_func(rcl_subscription_init, 4),
     nif_io_bound_func(rcl_subscription_fini, 2),
-#ifndef ROS_DISTRO_foxy
     nif_regular_func(rcl_subscription_set_on_new_message_callback, 1),
     nif_regular_func(rcl_subscription_clear_message_callback, 2),
-#endif
     nif_regular_func(rcl_take, 2),
     nif_io_bound_func(rcl_clock_init, 0),
     nif_io_bound_func(rcl_clock_fini, 1),

--- a/src/qos.c
+++ b/src/qos.c
@@ -2,7 +2,6 @@
 #include "terms.h"
 #include <erl_nif.h>
 #include <math.h>
-// IWYU pragma: no_include "rmw/time.h" for foxy
 #include <rmw/qos_profiles.h>
 #include <rmw/types.h>
 #include <stdbool.h>

--- a/src/rcl_subscription.c
+++ b/src/rcl_subscription.c
@@ -108,7 +108,6 @@ ERL_NIF_TERM nif_rcl_take(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   return raise(env, __FILE__, __LINE__);
 }
 
-#ifndef ROS_DISTRO_foxy
 static void new_message_callback(const void *user_data, size_t number_of_events) {
   ErlNifPid *pid_p = (ErlNifPid *)user_data;
 
@@ -161,4 +160,3 @@ ERL_NIF_TERM nif_rcl_subscription_clear_message_callback(ErlNifEnv *env, int arg
 
   return atom_ok;
 }
-#endif

--- a/test/rclex/nif_test.exs
+++ b/test/rclex/nif_test.exs
@@ -346,23 +346,21 @@ defmodule Rclex.NifTest do
       end
     end
 
-    if System.fetch_env!("ROS_DISTRO") != "foxy" do
-      test "rcl_subscription_set_on_new_message_callback!/1, rcl_subscription_clear_message_callback!/2",
-           %{
-             node: node,
-             type_support: type_support,
-             qos: qos
-           } do
-        subscription = Nif.rcl_subscription_init!(node, type_support, ~c"/topic", qos)
-        callback_resource = Nif.rcl_subscription_set_on_new_message_callback!(subscription)
+    test "rcl_subscription_set_on_new_message_callback!/1, rcl_subscription_clear_message_callback!/2",
+         %{
+           node: node,
+           type_support: type_support,
+           qos: qos
+         } do
+      subscription = Nif.rcl_subscription_init!(node, type_support, ~c"/topic", qos)
+      callback_resource = Nif.rcl_subscription_set_on_new_message_callback!(subscription)
 
-        assert is_reference(callback_resource)
+      assert is_reference(callback_resource)
 
-        assert Nif.rcl_subscription_clear_message_callback!(subscription, callback_resource) ==
-                 :ok
+      assert Nif.rcl_subscription_clear_message_callback!(subscription, callback_resource) ==
+               :ok
 
-        :ok = Nif.rcl_subscription_fini!(subscription, node)
-      end
+      :ok = Nif.rcl_subscription_fini!(subscription, node)
     end
   end
 


### PR DESCRIPTION
This PR removed code depending on Foxy, Galactic, and Iron, which have already reached EOL. Although it may be good idea to keep these codes because they were appropriately macro-switching, I want to suggest that removing them could improve maintainability and concentrate our development resources in the future.
For those who insist on using the older distributions, I have noted that they should be usable for v0.11.3 or earlier.

This PR will fix #333 

@pojiro please share your thoughts!! 

Just FYI, I have removed these codes found by grep, but are there any others left?