### PR TITLE
Improve ROS 2 builtin type `string` handling

### DIFF
--- a/lib/rclex/generators/msg_ex.ex
+++ b/lib/rclex/generators/msg_ex.ex
@@ -137,13 +137,7 @@ defmodule Rclex.Generators.MsgEx do
 
         # credo:disable-for-next-line Credo.Check.Refactor.Nesting
         case [type_tuple, name] do
-          [{:builtin_type, "string" <> _}, name] ->
-            "#{name}"
-
           [{:builtin_type, _type}, name] ->
-            "#{name}"
-
-          [{:builtin_type_array, "uint8[" <> _}, name] ->
             "#{name}"
 
           [{:builtin_type_array, _type}, name] ->
@@ -180,13 +174,7 @@ defmodule Rclex.Generators.MsgEx do
 
         # credo:disable-for-next-line Credo.Check.Refactor.Nesting
         case [type_tuple, name] do
-          [{:builtin_type, "string" <> _}, name] ->
-            "#{name}: #{name}"
-
           [{:builtin_type, _type}, name] ->
-            "#{name}: #{name}"
-
-          [{:builtin_type_array, "uint8[" <> _}, name] ->
             "#{name}: #{name}"
 
           [{:builtin_type_array, _type}, name] ->

--- a/lib/rclex/generators/msg_ex.ex
+++ b/lib/rclex/generators/msg_ex.ex
@@ -138,7 +138,7 @@ defmodule Rclex.Generators.MsgEx do
         # credo:disable-for-next-line Credo.Check.Refactor.Nesting
         case [type_tuple, name] do
           [{:builtin_type, "string" <> _}, name] ->
-            ~s/~c"\#{#{name}}"/
+            "#{name}"
 
           [{:builtin_type, _type}, name] ->
             "#{name}"
@@ -181,7 +181,7 @@ defmodule Rclex.Generators.MsgEx do
         # credo:disable-for-next-line Credo.Check.Refactor.Nesting
         case [type_tuple, name] do
           [{:builtin_type, "string" <> _}, name] ->
-            ~s/#{name}: "\#{#{name}}"/
+            "#{name}: #{name}"
 
           [{:builtin_type, _type}, name] ->
             "#{name}: #{name}"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,13 @@
+# About scripts
+
+These scripts are for development. So package doesn't include these.
+
+### `*_benchee.exs`
+
+You can run them by `mix run scripts/*_benchee.exs` under the project.
+
+### `iwyu.sh`
+
+You can use `iwyu`, `include-what-you-use` by `mix iwyu` which call this script.
+
+NOTE: `iwyu` is `[include-what-you-use](https://github.com/include-what-you-use/include-what-you-use)`.

--- a/scripts/std_msgs_msg_string_benchee.exs
+++ b/scripts/std_msgs_msg_string_benchee.exs
@@ -1,0 +1,50 @@
+alias Rclex.Pkgs.StdMsgs
+
+struct = %Rclex.Pkgs.StdMsgs.Msg.String{
+  data: for(_ <- 1..(2 ** 16), into: <<>>, do: <<0x30>>)
+}
+
+Benchee.run(%{
+  "create!/0" => {
+    fn ->
+      StdMsgs.Msg.String.create!()
+    end,
+    after_each: fn message ->
+      StdMsgs.Msg.String.destroy!(message)
+    end
+  },
+  "set!/2" => {
+    fn message ->
+      StdMsgs.Msg.String.set!(message, struct)
+      message
+    end,
+    before_each: fn _ ->
+      StdMsgs.Msg.String.create!()
+    end,
+    after_each: fn message ->
+      StdMsgs.Msg.String.destroy!(message)
+    end
+  },
+  "get!/1" => {
+    fn message ->
+      StdMsgs.Msg.String.get!(message)
+      message
+    end,
+    before_each: fn _ ->
+      message = StdMsgs.Msg.String.create!()
+      StdMsgs.Msg.String.set!(message, struct)
+      message
+    end,
+    after_each: fn message ->
+      StdMsgs.Msg.String.destroy!(message)
+    end
+  },
+  "destroy!/1" => {
+    fn message -> StdMsgs.Msg.String.destroy!(message) end,
+    before_each: fn _ ->
+      message = StdMsgs.Msg.String.create!()
+      StdMsgs.Msg.String.set!(message, struct)
+      message
+    end
+  }
+})

--- a/src/qos.c
+++ b/src/qos.c
@@ -3,6 +3,7 @@
 #include <erl_nif.h>
 #include <math.h>
 #include <rmw/qos_profiles.h>
+#include <rmw/time.h>
 #include <rmw/types.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/terms.c
+++ b/src/terms.c
@@ -1,6 +1,7 @@
 #include "terms.h"
 #include "macros.h"
 #include <erl_nif.h>
+#include <string.h>
 
 ERL_NIF_TERM atom_ok;
 ERL_NIF_TERM atom_error;
@@ -26,4 +27,11 @@ ERL_NIF_TERM nif_test_raise_with_message(ErlNifEnv *env, int argc, const ERL_NIF
   ignore_unused(argv);
 
   return raise_with_message(env, __FILE__, __LINE__, "test");
+}
+
+ERL_NIF_TERM enif_make_binary_wrapper(ErlNifEnv *env, const char *data, size_t size) {
+  ErlNifBinary binary;
+  if (!enif_alloc_binary(size, &binary)) return raise(env, __FILE__, __LINE__);
+  memcpy((void *)binary.data, (const void *)data, binary.size);
+  return enif_make_binary(env, &binary);
 }

--- a/src/terms.h
+++ b/src/terms.h
@@ -10,6 +10,7 @@ extern void make_common_atoms(ErlNifEnv *env);
 extern ERL_NIF_TERM nif_test_raise(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 extern ERL_NIF_TERM nif_test_raise_with_message(ErlNifEnv *env, int argc,
                                                 const ERL_NIF_TERM argv[]);
+extern ERL_NIF_TERM enif_make_binary_wrapper(ErlNifEnv *env, const char *data, size_t size);
 
 static inline ERL_NIF_TERM raise(ErlNifEnv *env, const char *file, int line) {
   char str[1024];

--- a/test/expected_files/sensor_msgs/msg/point_cloud.c
+++ b/test/expected_files/sensor_msgs/msg/point_cloud.c
@@ -108,20 +108,11 @@ ERL_NIF_TERM nif_sensor_msgs_msg_point_cloud_set(ErlNifEnv *env, int argc, const
     return enif_make_badarg(env);
   message_p->header.stamp.nanosec = header_stamp_nanosec;
 
-  unsigned int header_frame_id_length;
-#if (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17) // OTP-26 and later
-  if (!enif_get_string_length(env, header_tuple[1], &header_frame_id_length, ERL_NIF_LATIN1))
-    return enif_make_badarg(env);
-#else
-  if (!enif_get_list_length(env, header_tuple[1], &header_frame_id_length))
-    return enif_make_badarg(env);
-#endif
-
-  char header_frame_id[header_frame_id_length + 1];
-  if (enif_get_string(env, header_tuple[1], header_frame_id, header_frame_id_length + 1, ERL_NIF_LATIN1) <= 0)
+  ErlNifBinary header_frame_id_binary;
+  if (!enif_inspect_binary(env, header_tuple[1], &header_frame_id_binary))
     return enif_make_badarg(env);
 
-  if (!rosidl_runtime_c__String__assign(&(message_p->header.frame_id), header_frame_id))
+  if (!rosidl_runtime_c__String__assignn(&(message_p->header.frame_id), (const char *)header_frame_id_binary.data, header_frame_id_binary.size))
     return raise(env, __FILE__, __LINE__);
 
   unsigned int points_length;
@@ -180,20 +171,11 @@ ERL_NIF_TERM nif_sensor_msgs_msg_point_cloud_set(ErlNifEnv *env, int argc, const
     if (!enif_get_tuple(env, channels_head, &channels_i_arity, &channels_i_tuple))
       return enif_make_badarg(env);
 
-    unsigned int channels_i_name_length;
-#if (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17) // OTP-26 and later
-    if (!enif_get_string_length(env, channels_i_tuple[0], &channels_i_name_length, ERL_NIF_LATIN1))
-      return enif_make_badarg(env);
-#else
-    if (!enif_get_list_length(env, channels_i_tuple[0], &channels_i_name_length))
-      return enif_make_badarg(env);
-#endif
-
-    char channels_i_name[channels_i_name_length + 1];
-    if (enif_get_string(env, channels_i_tuple[0], channels_i_name, channels_i_name_length + 1, ERL_NIF_LATIN1) <= 0)
+    ErlNifBinary channels_i_name_binary;
+    if (!enif_inspect_binary(env, channels_i_tuple[0], &channels_i_name_binary))
       return enif_make_badarg(env);
 
-    if (!rosidl_runtime_c__String__assign(&(message_p->channels.data[channels_i].name), channels_i_name))
+    if (!rosidl_runtime_c__String__assignn(&(message_p->channels.data[channels_i].name), (const char *)channels_i_name_binary.data, channels_i_name_binary.size))
       return raise(env, __FILE__, __LINE__);
 
     unsigned int channels_i_values_length;
@@ -254,7 +236,7 @@ ERL_NIF_TERM nif_sensor_msgs_msg_point_cloud_get(ErlNifEnv *env, int argc, const
     }
 
     channels[channels_i] = enif_make_tuple(env, 2,
-      enif_make_string(env, message_p->channels.data[channels_i].name.data, ERL_NIF_LATIN1),
+      enif_make_binary_wrapper(env, message_p->channels.data[channels_i].name.data, message_p->channels.data[channels_i].name.size),
       enif_make_list_from_array(env, channels_values, message_p->channels.data[channels_i].values.size)
     );
   }
@@ -265,7 +247,7 @@ ERL_NIF_TERM nif_sensor_msgs_msg_point_cloud_get(ErlNifEnv *env, int argc, const
         enif_make_int(env, message_p->header.stamp.sec),
         enif_make_uint(env, message_p->header.stamp.nanosec)
       ),
-      enif_make_string(env, message_p->header.frame_id.data, ERL_NIF_LATIN1)
+      enif_make_binary_wrapper(env, message_p->header.frame_id.data, message_p->header.frame_id.size)
     ),
     enif_make_list_from_array(env, points, message_p->points.size),
     enif_make_list_from_array(env, channels, message_p->channels.size)

--- a/test/expected_files/sensor_msgs/msg/point_cloud_get_fun.txt
+++ b/test/expected_files/sensor_msgs/msg/point_cloud_get_fun.txt
@@ -21,7 +21,7 @@
     }
 
     channels[channels_i] = enif_make_tuple(env, 2,
-      enif_make_string(env, message_p->channels.data[channels_i].name.data, ERL_NIF_LATIN1),
+      enif_make_binary_wrapper(env, message_p->channels.data[channels_i].name.data, message_p->channels.data[channels_i].name.size),
       enif_make_list_from_array(env, channels_values, message_p->channels.data[channels_i].values.size)
     );
   }
@@ -32,7 +32,7 @@
         enif_make_int(env, message_p->header.stamp.sec),
         enif_make_uint(env, message_p->header.stamp.nanosec)
       ),
-      enif_make_string(env, message_p->header.frame_id.data, ERL_NIF_LATIN1)
+      enif_make_binary_wrapper(env, message_p->header.frame_id.data, message_p->header.frame_id.size)
     ),
     enif_make_list_from_array(env, points, message_p->points.size),
     enif_make_list_from_array(env, channels, message_p->channels.size)

--- a/test/expected_files/sensor_msgs/msg/point_cloud_set_fun.txt
+++ b/test/expected_files/sensor_msgs/msg/point_cloud_set_fun.txt
@@ -18,20 +18,11 @@
     return enif_make_badarg(env);
   message_p->header.stamp.nanosec = header_stamp_nanosec;
 
-  unsigned int header_frame_id_length;
-#if (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17) // OTP-26 and later
-  if (!enif_get_string_length(env, header_tuple[1], &header_frame_id_length, ERL_NIF_LATIN1))
-    return enif_make_badarg(env);
-#else
-  if (!enif_get_list_length(env, header_tuple[1], &header_frame_id_length))
-    return enif_make_badarg(env);
-#endif
-
-  char header_frame_id[header_frame_id_length + 1];
-  if (enif_get_string(env, header_tuple[1], header_frame_id, header_frame_id_length + 1, ERL_NIF_LATIN1) <= 0)
+  ErlNifBinary header_frame_id_binary;
+  if (!enif_inspect_binary(env, header_tuple[1], &header_frame_id_binary))
     return enif_make_badarg(env);
 
-  if (!rosidl_runtime_c__String__assign(&(message_p->header.frame_id), header_frame_id))
+  if (!rosidl_runtime_c__String__assignn(&(message_p->header.frame_id), (const char *)header_frame_id_binary.data, header_frame_id_binary.size))
     return raise(env, __FILE__, __LINE__);
 
   unsigned int points_length;
@@ -90,20 +81,11 @@
     if (!enif_get_tuple(env, channels_head, &channels_i_arity, &channels_i_tuple))
       return enif_make_badarg(env);
 
-    unsigned int channels_i_name_length;
-#if (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17) // OTP-26 and later
-    if (!enif_get_string_length(env, channels_i_tuple[0], &channels_i_name_length, ERL_NIF_LATIN1))
-      return enif_make_badarg(env);
-#else
-    if (!enif_get_list_length(env, channels_i_tuple[0], &channels_i_name_length))
-      return enif_make_badarg(env);
-#endif
-
-    char channels_i_name[channels_i_name_length + 1];
-    if (enif_get_string(env, channels_i_tuple[0], channels_i_name, channels_i_name_length + 1, ERL_NIF_LATIN1) <= 0)
+    ErlNifBinary channels_i_name_binary;
+    if (!enif_inspect_binary(env, channels_i_tuple[0], &channels_i_name_binary))
       return enif_make_badarg(env);
 
-    if (!rosidl_runtime_c__String__assign(&(message_p->channels.data[channels_i].name), channels_i_name))
+    if (!rosidl_runtime_c__String__assignn(&(message_p->channels.data[channels_i].name), (const char *)channels_i_name_binary.data, channels_i_name_binary.size))
       return raise(env, __FILE__, __LINE__);
 
     unsigned int channels_i_values_length;

--- a/test/expected_files/std_msgs/msg/multi_array_dimension.c
+++ b/test/expected_files/std_msgs/msg/multi_array_dimension.c
@@ -76,20 +76,11 @@ ERL_NIF_TERM nif_std_msgs_msg_multi_array_dimension_set(ErlNifEnv *env, int argc
   const ERL_NIF_TERM *tuple;
   if (!enif_get_tuple(env, argv[1], &arity, &tuple)) return enif_make_badarg(env);
 
-  unsigned int label_length;
-#if (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17) // OTP-26 and later
-  if (!enif_get_string_length(env, tuple[0], &label_length, ERL_NIF_LATIN1))
-    return enif_make_badarg(env);
-#else
-  if (!enif_get_list_length(env, tuple[0], &label_length))
-    return enif_make_badarg(env);
-#endif
-
-  char label[label_length + 1];
-  if (enif_get_string(env, tuple[0], label, label_length + 1, ERL_NIF_LATIN1) <= 0)
+  ErlNifBinary label_binary;
+  if (!enif_inspect_binary(env, tuple[0], &label_binary))
     return enif_make_badarg(env);
 
-  if (!rosidl_runtime_c__String__assign(&(message_p->label), label))
+  if (!rosidl_runtime_c__String__assignn(&(message_p->label), (const char *)label_binary.data, label_binary.size))
     return raise(env, __FILE__, __LINE__);
 
   unsigned int size;
@@ -115,7 +106,7 @@ ERL_NIF_TERM nif_std_msgs_msg_multi_array_dimension_get(ErlNifEnv *env, int argc
   std_msgs__msg__MultiArrayDimension *message_p = (std_msgs__msg__MultiArrayDimension *)*ros_message_pp;
 
   return enif_make_tuple(env, 3,
-    enif_make_string(env, message_p->label.data, ERL_NIF_LATIN1),
+    enif_make_binary_wrapper(env, message_p->label.data, message_p->label.size),
     enif_make_uint(env, message_p->size),
     enif_make_uint(env, message_p->stride)
   );

--- a/test/expected_files/std_msgs/msg/multi_array_dimension_get_fun.txt
+++ b/test/expected_files/std_msgs/msg/multi_array_dimension_get_fun.txt
@@ -1,5 +1,5 @@
   return enif_make_tuple(env, 3,
-    enif_make_string(env, message_p->label.data, ERL_NIF_LATIN1),
+    enif_make_binary_wrapper(env, message_p->label.data, message_p->label.size),
     enif_make_uint(env, message_p->size),
     enif_make_uint(env, message_p->stride)
   );

--- a/test/expected_files/std_msgs/msg/multi_array_dimension_set_fun.txt
+++ b/test/expected_files/std_msgs/msg/multi_array_dimension_set_fun.txt
@@ -1,17 +1,8 @@
-  unsigned int label_length;
-#if (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17) // OTP-26 and later
-  if (!enif_get_string_length(env, tuple[0], &label_length, ERL_NIF_LATIN1))
-    return enif_make_badarg(env);
-#else
-  if (!enif_get_list_length(env, tuple[0], &label_length))
-    return enif_make_badarg(env);
-#endif
-
-  char label[label_length + 1];
-  if (enif_get_string(env, tuple[0], label, label_length + 1, ERL_NIF_LATIN1) <= 0)
+  ErlNifBinary label_binary;
+  if (!enif_inspect_binary(env, tuple[0], &label_binary))
     return enif_make_badarg(env);
 
-  if (!rosidl_runtime_c__String__assign(&(message_p->label), label))
+  if (!rosidl_runtime_c__String__assignn(&(message_p->label), (const char *)label_binary.data, label_binary.size))
     return raise(env, __FILE__, __LINE__);
 
   unsigned int size;

--- a/test/expected_files/std_msgs/msg/multi_array_layout.c
+++ b/test/expected_files/std_msgs/msg/multi_array_layout.c
@@ -99,20 +99,11 @@ ERL_NIF_TERM nif_std_msgs_msg_multi_array_layout_set(ErlNifEnv *env, int argc, c
     if (!enif_get_tuple(env, dim_head, &dim_i_arity, &dim_i_tuple))
       return enif_make_badarg(env);
 
-    unsigned int dim_i_label_length;
-#if (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17) // OTP-26 and later
-    if (!enif_get_string_length(env, dim_i_tuple[0], &dim_i_label_length, ERL_NIF_LATIN1))
-      return enif_make_badarg(env);
-#else
-    if (!enif_get_list_length(env, dim_i_tuple[0], &dim_i_label_length))
-      return enif_make_badarg(env);
-#endif
-
-    char dim_i_label[dim_i_label_length + 1];
-    if (enif_get_string(env, dim_i_tuple[0], dim_i_label, dim_i_label_length + 1, ERL_NIF_LATIN1) <= 0)
+    ErlNifBinary dim_i_label_binary;
+    if (!enif_inspect_binary(env, dim_i_tuple[0], &dim_i_label_binary))
       return enif_make_badarg(env);
 
-    if (!rosidl_runtime_c__String__assign(&(message_p->dim.data[dim_i].label), dim_i_label))
+    if (!rosidl_runtime_c__String__assignn(&(message_p->dim.data[dim_i].label), (const char *)dim_i_label_binary.data, dim_i_label_binary.size))
       return raise(env, __FILE__, __LINE__);
 
     unsigned int dim_i_size;
@@ -148,7 +139,7 @@ ERL_NIF_TERM nif_std_msgs_msg_multi_array_layout_get(ErlNifEnv *env, int argc, c
   for (size_t dim_i = 0; dim_i < message_p->dim.size; ++dim_i)
   {
     dim[dim_i] = enif_make_tuple(env, 3,
-      enif_make_string(env, message_p->dim.data[dim_i].label.data, ERL_NIF_LATIN1),
+      enif_make_binary_wrapper(env, message_p->dim.data[dim_i].label.data, message_p->dim.data[dim_i].label.size),
       enif_make_uint(env, message_p->dim.data[dim_i].size),
       enif_make_uint(env, message_p->dim.data[dim_i].stride)
     );

--- a/test/expected_files/std_msgs/msg/multi_array_layout_get_fun.txt
+++ b/test/expected_files/std_msgs/msg/multi_array_layout_get_fun.txt
@@ -3,7 +3,7 @@
   for (size_t dim_i = 0; dim_i < message_p->dim.size; ++dim_i)
   {
     dim[dim_i] = enif_make_tuple(env, 3,
-      enif_make_string(env, message_p->dim.data[dim_i].label.data, ERL_NIF_LATIN1),
+      enif_make_binary_wrapper(env, message_p->dim.data[dim_i].label.data, message_p->dim.data[dim_i].label.size),
       enif_make_uint(env, message_p->dim.data[dim_i].size),
       enif_make_uint(env, message_p->dim.data[dim_i].stride)
     );

--- a/test/expected_files/std_msgs/msg/multi_array_layout_set_fun.txt
+++ b/test/expected_files/std_msgs/msg/multi_array_layout_set_fun.txt
@@ -18,20 +18,11 @@
     if (!enif_get_tuple(env, dim_head, &dim_i_arity, &dim_i_tuple))
       return enif_make_badarg(env);
 
-    unsigned int dim_i_label_length;
-#if (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17) // OTP-26 and later
-    if (!enif_get_string_length(env, dim_i_tuple[0], &dim_i_label_length, ERL_NIF_LATIN1))
-      return enif_make_badarg(env);
-#else
-    if (!enif_get_list_length(env, dim_i_tuple[0], &dim_i_label_length))
-      return enif_make_badarg(env);
-#endif
-
-    char dim_i_label[dim_i_label_length + 1];
-    if (enif_get_string(env, dim_i_tuple[0], dim_i_label, dim_i_label_length + 1, ERL_NIF_LATIN1) <= 0)
+    ErlNifBinary dim_i_label_binary;
+    if (!enif_inspect_binary(env, dim_i_tuple[0], &dim_i_label_binary))
       return enif_make_badarg(env);
 
-    if (!rosidl_runtime_c__String__assign(&(message_p->dim.data[dim_i].label), dim_i_label))
+    if (!rosidl_runtime_c__String__assignn(&(message_p->dim.data[dim_i].label), (const char *)dim_i_label_binary.data, dim_i_label_binary.size))
       return raise(env, __FILE__, __LINE__);
 
     unsigned int dim_i_size;

--- a/test/expected_files/std_msgs/msg/string.c
+++ b/test/expected_files/std_msgs/msg/string.c
@@ -76,20 +76,11 @@ ERL_NIF_TERM nif_std_msgs_msg_string_set(ErlNifEnv *env, int argc, const ERL_NIF
   const ERL_NIF_TERM *tuple;
   if (!enif_get_tuple(env, argv[1], &arity, &tuple)) return enif_make_badarg(env);
 
-  unsigned int data_length;
-#if (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17) // OTP-26 and later
-  if (!enif_get_string_length(env, tuple[0], &data_length, ERL_NIF_LATIN1))
-    return enif_make_badarg(env);
-#else
-  if (!enif_get_list_length(env, tuple[0], &data_length))
-    return enif_make_badarg(env);
-#endif
-
-  char data[data_length + 1];
-  if (enif_get_string(env, tuple[0], data, data_length + 1, ERL_NIF_LATIN1) <= 0)
+  ErlNifBinary data_binary;
+  if (!enif_inspect_binary(env, tuple[0], &data_binary))
     return enif_make_badarg(env);
 
-  if (!rosidl_runtime_c__String__assign(&(message_p->data), data))
+  if (!rosidl_runtime_c__String__assignn(&(message_p->data), (const char *)data_binary.data, data_binary.size))
     return raise(env, __FILE__, __LINE__);
 
   return atom_ok;
@@ -105,7 +96,7 @@ ERL_NIF_TERM nif_std_msgs_msg_string_get(ErlNifEnv *env, int argc, const ERL_NIF
   std_msgs__msg__String *message_p = (std_msgs__msg__String *)*ros_message_pp;
 
   return enif_make_tuple(env, 1,
-    enif_make_string(env, message_p->data.data, ERL_NIF_LATIN1)
+    enif_make_binary_wrapper(env, message_p->data.data, message_p->data.size)
   );
 }
 // clang-format on

--- a/test/expected_files/std_msgs/msg/string.ex
+++ b/test/expected_files/std_msgs/msg/string.ex
@@ -29,10 +29,10 @@ defmodule Rclex.Pkgs.StdMsgs.Msg.String do
   end
 
   def to_tuple(%__MODULE__{data: data}) do
-    {~c"#{data}"}
+    {data}
   end
 
   def to_struct({data}) do
-    %__MODULE__{data: "#{data}"}
+    %__MODULE__{data: data}
   end
 end

--- a/test/expected_files/std_msgs/msg/string_get_fun.txt
+++ b/test/expected_files/std_msgs/msg/string_get_fun.txt
@@ -1,3 +1,3 @@
   return enif_make_tuple(env, 1,
-    enif_make_string(env, message_p->data.data, ERL_NIF_LATIN1)
+    enif_make_binary_wrapper(env, message_p->data.data, message_p->data.size)
   );

--- a/test/expected_files/std_msgs/msg/string_set_fun.txt
+++ b/test/expected_files/std_msgs/msg/string_set_fun.txt
@@ -1,15 +1,6 @@
-  unsigned int data_length;
-#if (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17) // OTP-26 and later
-  if (!enif_get_string_length(env, tuple[0], &data_length, ERL_NIF_LATIN1))
-    return enif_make_badarg(env);
-#else
-  if (!enif_get_list_length(env, tuple[0], &data_length))
-    return enif_make_badarg(env);
-#endif
-
-  char data[data_length + 1];
-  if (enif_get_string(env, tuple[0], data, data_length + 1, ERL_NIF_LATIN1) <= 0)
+  ErlNifBinary data_binary;
+  if (!enif_inspect_binary(env, tuple[0], &data_binary))
     return enif_make_badarg(env);
 
-  if (!rosidl_runtime_c__String__assign(&(message_p->data), data))
+  if (!rosidl_runtime_c__String__assignn(&(message_p->data), (const char *)data_binary.data, data_binary.size))
     return raise(env, __FILE__, __LINE__);

--- a/test/expected_files/std_msgs/msg/u_int32_multi_array.c
+++ b/test/expected_files/std_msgs/msg/u_int32_multi_array.c
@@ -107,20 +107,11 @@ ERL_NIF_TERM nif_std_msgs_msg_u_int32_multi_array_set(ErlNifEnv *env, int argc, 
     if (!enif_get_tuple(env, layout_dim_head, &layout_dim_i_arity, &layout_dim_i_tuple))
       return enif_make_badarg(env);
 
-    unsigned int layout_dim_i_label_length;
-#if (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17) // OTP-26 and later
-    if (!enif_get_string_length(env, layout_dim_i_tuple[0], &layout_dim_i_label_length, ERL_NIF_LATIN1))
-      return enif_make_badarg(env);
-#else
-    if (!enif_get_list_length(env, layout_dim_i_tuple[0], &layout_dim_i_label_length))
-      return enif_make_badarg(env);
-#endif
-
-    char layout_dim_i_label[layout_dim_i_label_length + 1];
-    if (enif_get_string(env, layout_dim_i_tuple[0], layout_dim_i_label, layout_dim_i_label_length + 1, ERL_NIF_LATIN1) <= 0)
+    ErlNifBinary layout_dim_i_label_binary;
+    if (!enif_inspect_binary(env, layout_dim_i_tuple[0], &layout_dim_i_label_binary))
       return enif_make_badarg(env);
 
-    if (!rosidl_runtime_c__String__assign(&(message_p->layout.dim.data[layout_dim_i].label), layout_dim_i_label))
+    if (!rosidl_runtime_c__String__assignn(&(message_p->layout.dim.data[layout_dim_i].label), (const char *)layout_dim_i_label_binary.data, layout_dim_i_label_binary.size))
       return raise(env, __FILE__, __LINE__);
 
     unsigned int layout_dim_i_size;
@@ -178,7 +169,7 @@ ERL_NIF_TERM nif_std_msgs_msg_u_int32_multi_array_get(ErlNifEnv *env, int argc, 
   for (size_t layout_dim_i = 0; layout_dim_i < message_p->layout.dim.size; ++layout_dim_i)
   {
     layout_dim[layout_dim_i] = enif_make_tuple(env, 3,
-      enif_make_string(env, message_p->layout.dim.data[layout_dim_i].label.data, ERL_NIF_LATIN1),
+      enif_make_binary_wrapper(env, message_p->layout.dim.data[layout_dim_i].label.data, message_p->layout.dim.data[layout_dim_i].label.size),
       enif_make_uint(env, message_p->layout.dim.data[layout_dim_i].size),
       enif_make_uint(env, message_p->layout.dim.data[layout_dim_i].stride)
     );

--- a/test/expected_files/std_msgs/msg/u_int32_multi_array_get_fun.txt
+++ b/test/expected_files/std_msgs/msg/u_int32_multi_array_get_fun.txt
@@ -3,7 +3,7 @@
   for (size_t layout_dim_i = 0; layout_dim_i < message_p->layout.dim.size; ++layout_dim_i)
   {
     layout_dim[layout_dim_i] = enif_make_tuple(env, 3,
-      enif_make_string(env, message_p->layout.dim.data[layout_dim_i].label.data, ERL_NIF_LATIN1),
+      enif_make_binary_wrapper(env, message_p->layout.dim.data[layout_dim_i].label.data, message_p->layout.dim.data[layout_dim_i].label.size),
       enif_make_uint(env, message_p->layout.dim.data[layout_dim_i].size),
       enif_make_uint(env, message_p->layout.dim.data[layout_dim_i].stride)
     );

--- a/test/expected_files/std_msgs/msg/u_int32_multi_array_set_fun.txt
+++ b/test/expected_files/std_msgs/msg/u_int32_multi_array_set_fun.txt
@@ -23,20 +23,11 @@
     if (!enif_get_tuple(env, layout_dim_head, &layout_dim_i_arity, &layout_dim_i_tuple))
       return enif_make_badarg(env);
 
-    unsigned int layout_dim_i_label_length;
-#if (ERL_NIF_MAJOR_VERSION == 2 && ERL_NIF_MINOR_VERSION >= 17) // OTP-26 and later
-    if (!enif_get_string_length(env, layout_dim_i_tuple[0], &layout_dim_i_label_length, ERL_NIF_LATIN1))
-      return enif_make_badarg(env);
-#else
-    if (!enif_get_list_length(env, layout_dim_i_tuple[0], &layout_dim_i_label_length))
-      return enif_make_badarg(env);
-#endif
-
-    char layout_dim_i_label[layout_dim_i_label_length + 1];
-    if (enif_get_string(env, layout_dim_i_tuple[0], layout_dim_i_label, layout_dim_i_label_length + 1, ERL_NIF_LATIN1) <= 0)
+    ErlNifBinary layout_dim_i_label_binary;
+    if (!enif_inspect_binary(env, layout_dim_i_tuple[0], &layout_dim_i_label_binary))
       return enif_make_badarg(env);
 
-    if (!rosidl_runtime_c__String__assign(&(message_p->layout.dim.data[layout_dim_i].label), layout_dim_i_label))
+    if (!rosidl_runtime_c__String__assignn(&(message_p->layout.dim.data[layout_dim_i].label), (const char *)layout_dim_i_label_binary.data, layout_dim_i_label_binary.size))
       return raise(env, __FILE__, __LINE__);
 
     unsigned int layout_dim_i_size;

--- a/test/rclex/generators/msg_ex_test.exs
+++ b/test/rclex/generators/msg_ex_test.exs
@@ -134,8 +134,8 @@ defmodule Rclex.Generators.MsgExTest do
 
     for {ros2_message_type, expected} <- [
           {"std_msgs/msg/Empty", ""},
-          {"std_msgs/msg/String", "~c\"\#{data}\""},
-          {"std_msgs/msg/MultiArrayDimension", "~c\"\#{label}\",\nsize,\nstride"},
+          {"std_msgs/msg/String", "data"},
+          {"std_msgs/msg/MultiArrayDimension", "label,\nsize,\nstride"},
           {"std_msgs/msg/MultiArrayLayout",
            "for struct <- dim do\n  Rclex.Pkgs.StdMsgs.Msg.MultiArrayDimension.to_tuple(struct)\nend,\ndata_offset"},
           {"std_msgs/msg/UInt32MultiArray",
@@ -155,9 +155,8 @@ defmodule Rclex.Generators.MsgExTest do
 
     for {ros2_message_type, expected} <- [
           {"std_msgs/msg/Empty", ""},
-          {"std_msgs/msg/String", "data: \"\#{data}\""},
-          {"std_msgs/msg/MultiArrayDimension",
-           "label: \"\#{label}\",\nsize: size,\nstride: stride"},
+          {"std_msgs/msg/String", "data: data"},
+          {"std_msgs/msg/MultiArrayDimension", "label: label,\nsize: size,\nstride: stride"},
           {"std_msgs/msg/MultiArrayLayout",
            "dim:\n  for tuple <- dim do\n    Rclex.Pkgs.StdMsgs.Msg.MultiArrayDimension.to_struct(tuple)\n  end,\ndata_offset: data_offset"},
           {"std_msgs/msg/UInt32MultiArray",

--- a/test/rclex/nif_test.exs
+++ b/test/rclex/nif_test.exs
@@ -11,7 +11,7 @@ defmodule Rclex.NifTest do
       rescue
         ex in [ErlangError] ->
           %ErlangError{original: charlist, reason: nil} = ex
-          assert "at src/terms.c:21" <> _ = to_string(charlist)
+          assert "at src/terms.c:22" <> _ = to_string(charlist)
       end
     end
 
@@ -21,7 +21,7 @@ defmodule Rclex.NifTest do
       rescue
         ex in [ErlangError] ->
           %ErlangError{original: charlist, reason: nil} = ex
-          assert "at src/terms.c:28" <> _ = to_string(charlist)
+          assert "at src/terms.c:29" <> _ = to_string(charlist)
           assert String.ends_with?(to_string(charlist), "test")
       end
     end
@@ -88,8 +88,8 @@ defmodule Rclex.NifTest do
 
       assert Nif.sensor_msgs_msg_point_cloud_set!(
                message,
-               {{{-9, 8}, ~c"test"}, [{0.1, 0.2, 0.3}, {0.4, 0.5, 0.6}, {0.7, 0.8, 0.9}],
-                [{~c"channels_name", [0.0]}]}
+               {{{-9, 8}, "test"}, [{0.1, 0.2, 0.3}, {0.4, 0.5, 0.6}, {0.7, 0.8, 0.9}],
+                [{"channels_name", [0.0]}]}
              ) == :ok
 
       # assert Nif.sensor_msgs_msg_point_cloud_get!(message) ==
@@ -113,8 +113,8 @@ defmodule Rclex.NifTest do
 
     test "std_msgs_msg_string_set!/1, std_msgs_msg_string_get!/1" do
       message = Nif.std_msgs_msg_string_create!()
-      assert Nif.std_msgs_msg_string_set!(message, {~c"test"}) == :ok
-      assert Nif.std_msgs_msg_string_get!(message) == {~c"test"}
+      assert Nif.std_msgs_msg_string_set!(message, {"test"}) == :ok
+      assert Nif.std_msgs_msg_string_get!(message) == {"test"}
       :ok = Nif.std_msgs_msg_string_destroy!(message)
     end
   end
@@ -132,8 +132,8 @@ defmodule Rclex.NifTest do
 
     test "std_msgs_msg_multi_array_dimension_set!/1, std_msgs_msg_multi_array_dimension_get!/1" do
       message = Nif.std_msgs_msg_multi_array_dimension_create!()
-      assert Nif.std_msgs_msg_multi_array_dimension_set!(message, {~c"1", 2, 3}) == :ok
-      assert Nif.std_msgs_msg_multi_array_dimension_get!(message) == {~c"1", 2, 3}
+      assert Nif.std_msgs_msg_multi_array_dimension_set!(message, {"1", 2, 3}) == :ok
+      assert Nif.std_msgs_msg_multi_array_dimension_get!(message) == {"1", 2, 3}
       :ok = Nif.std_msgs_msg_multi_array_dimension_destroy!(message)
     end
   end
@@ -154,11 +154,11 @@ defmodule Rclex.NifTest do
 
       assert Nif.std_msgs_msg_multi_array_layout_set!(
                message,
-               {[{~c"1", 2, 3}, {~c"4", 5, 6}, {~c"7", 8, 9}], 10}
+               {[{"1", 2, 3}, {"4", 5, 6}, {"7", 8, 9}], 10}
              ) == :ok
 
       assert Nif.std_msgs_msg_multi_array_layout_get!(message) ==
-               {[{~c"1", 2, 3}, {~c"4", 5, 6}, {~c"7", 8, 9}], 10}
+               {[{"1", 2, 3}, {"4", 5, 6}, {"7", 8, 9}], 10}
 
       :ok = Nif.std_msgs_msg_multi_array_layout_destroy!(message)
     end
@@ -180,11 +180,11 @@ defmodule Rclex.NifTest do
 
       assert Nif.std_msgs_msg_u_int32_multi_array_set!(
                message,
-               {{[{~c"test", 2, 3}, {~c"4", 5, 6}, {~c"7", 8, 9}], 10}, [1, 2, 3]}
+               {{[{"test", 2, 3}, {"4", 5, 6}, {"7", 8, 9}], 10}, [1, 2, 3]}
              ) == :ok
 
       assert Nif.std_msgs_msg_u_int32_multi_array_get!(message) ==
-               {{[{~c"test", 2, 3}, {~c"4", 5, 6}, {~c"7", 8, 9}], 10}, [1, 2, 3]}
+               {{[{"test", 2, 3}, {"4", 5, 6}, {"7", 8, 9}], 10}, [1, 2, 3]}
 
       :ok = Nif.std_msgs_msg_u_int32_multi_array_destroy!(message)
     end
@@ -276,7 +276,7 @@ defmodule Rclex.NifTest do
 
       wait_set = Nif.rcl_wait_set_init_subscription!(context)
       message = Nif.std_msgs_msg_string_create!()
-      :ok = Nif.std_msgs_msg_string_set!(message, {~c"Hello from Rclex"})
+      :ok = Nif.std_msgs_msg_string_set!(message, {"Hello from Rclex"})
 
       on_exit(fn ->
         Nif.std_msgs_msg_string_destroy!(message)
@@ -307,7 +307,7 @@ defmodule Rclex.NifTest do
       :ok = Nif.rcl_publish!(publisher, message)
       :ok = Nif.rcl_wait_subscription!(wait_set, 1000, subscription)
       assert Nif.rcl_take!(subscription, message) == :ok
-      assert Nif.std_msgs_msg_string_get!(message) == {~c"Hello from Rclex"}
+      assert Nif.std_msgs_msg_string_get!(message) == {"Hello from Rclex"}
     end
   end
 


### PR DESCRIPTION
This PR improves ROS 2 builtin type `string` handling, `get!` and `set!`, especially for long string message, like over `2**16` bytes.

Until now we treat the `string` as Erlang string, it means char array, this PR changes it as Erlang binary.
This PR doesn't change user API.

Left todos are following,

- [x] fix tests

## bench

### env

```
Operating System: Linux
CPU Information: Intel(R) Core(TM) Ultra 7 155U
Number of Available Cores: 14
Available memory: 30.86 GB
Elixir 1.17.3
Erlang 27.2.4
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 28 s
```

### Before

```bash
Name                 ips        average  deviation         median         99th %
create!/0      1200.10 K        0.83 μs  ±7282.50%       0.155 μs        0.56 μs
destroy!/1      613.62 K        1.63 μs   ±197.89%        1.48 μs        3.91 μs
get!/1            2.69 K      371.08 μs    ±50.20%      259.41 μs      924.29 μs
set!/2            2.59 K      386.75 μs    ±50.62%      267.64 μs      904.49 μs

Comparison:
create!/0      1200.10 K
destroy!/1      613.62 K - 1.96x slower +0.80 μs
get!/1            2.69 K - 445.33x slower +370.25 μs
set!/2            2.59 K - 464.13x slower +385.91 μs
```

### After

```bash
Name                 ips        average  deviation         median         99th %
create!/0      1306.41 K        0.77 μs  ±7568.95%        0.22 μs        0.33 μs
destroy!/1      846.92 K        1.18 μs    ±24.47%        1.15 μs        1.46 μs
set!/2          404.17 K        2.47 μs   ±363.48%        2.39 μs        3.35 μs
get!/1          366.45 K        2.73 μs   ±360.36%        2.49 μs        4.92 μs

Comparison:
create!/0      1306.41 K
destroy!/1      846.92 K - 1.54x slower +0.42 μs
set!/2          404.17 K - 3.23x slower +1.71 μs
get!/1          366.45 K - 3.57x slower +1.96 μs
```